### PR TITLE
ci(linter): use repo eslint configuration

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,9 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
+          LINTER_RULES_PATH: .
+          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.json
+          JAVASCRIPT_DEFAULT_STYLE: prettier
           DEFAULT_BRANCH: v3.x
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_INCLUDE: .*src/.*


### PR DESCRIPTION
Use the eslinter configuration from the repository instead of a default one.