### PR TITLE
feat: support custom variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
     - [Slug variables](#slug-variables)
     - [Slug URL variables](#slug-url-variables)
     - [Short variables](#short-variables)
+    - [Custom variables](#custom-variables)
   - [Contribute](#contribute)
   - [Troubleshooting](#troubleshooting)
     - [One of environement variable don't work as intended](#one-of-environement-variable-dont-work-as-intended)
@@ -107,6 +108,31 @@ Check for more [examples][examples] (OS usage, URL use, ...)
 | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [GITHUB_SHA_SHORT](docs/short-variables.md#github_sha_short)                                                         | GITHUB_SHA                                   | The commit SHA that triggered the workflow.                                                                                                                                                                                           |
 | [GITHUB_EVENT<br>_PULL_REQUEST<br>_HEAD_SHA_SHORT](docs/short-variables.md#github_event_pull_request_head_sha_short) | _github.event<br>.pull_request<br>.head.sha_ | The commit SHA on pull request that trigger workflow.<br>Only set for [following webhook events][4]<ul><li>`pull_request`</li><li>`pull_request_review`</li><li>`pull_request_review_comment`</li><li>`pull_request_target`</li></ul> |
+
+### Custom variables
+
+If you need `slug` or `short` versions of other environment values, you can use the following snippets
+
+- To get access to
+
+  - `<VAR>_SLUG`
+  - `<VAR>_SLUG_URL`
+  - `<VAR>_SLUG_CS`
+  - `<VAR>_SLUG_URL_CS`
+
+  ```yaml
+  - uses: rlespinasse/github-slug-action@v3.x
+    with:
+      custom_slugs: "SOME_VARIABLE,ANOTHER_VARIABLE"
+  ```
+
+- To get access to `<VAR>_SHORT`
+
+  ```yaml
+  - uses: rlespinasse/github-slug-action@v3.x
+    with:
+      custom_shorts: "SOME_VARIABLE,ANOTHER_VARIABLE"
+  ```
 
 ## Contribute
 

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,16 @@
 name: "GitHub Slug Action"
 description: "GitHub Action to expose slug value of environment variables inside your GitHub workflow"
-author: 'rlespinasse'
+author: "rlespinasse"
+inputs:
+  custom_slugs:
+    description: List of environment variables to be slugify (separated by comma)
+    required: false
+  custom_shorts:
+    description: List of environment variables to be shorted (separated by comma)
+    required: false
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: "node12"
+  main: "dist/index.js"
 branding:
   icon: "minimize"
   color: "blue"

--- a/examples/custom.yml
+++ b/examples/custom.yml
@@ -1,0 +1,42 @@
+name: Custom environment variables
+
+on: push
+
+jobs:
+  custom_slugs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rlespinasse/github-slug-action@v3.x
+        with:
+          custom_slugs: "SOME_VARIABLE,ANOTHER_VARIABLE"
+        env:
+          SOME_VARIABLE: Some Value
+          ANOTHER_VARIABLE: Another Value
+      - run: |
+          echo "SOME_VARIABLE"
+          echo "  Slug                    : ${{ env.SOME_VARIABLE_SLUG }}"
+          echo "  Slug URL                : ${{ env.SOME_VARIABLE_SLUG_URL }}"
+          echo "  Slug Case-Sensitive     : ${{ env.SOME_VARIABLE_SLUG_CS }}"
+          echo "  Slug URL Case-Sensitive : ${{ env.SOME_VARIABLE_SLUG_URL_CS }}"
+          echo "ANOTHER_VARIABLE"
+          echo "  Slug                    : ${{ env.ANOTHER_VARIABLE_SLUG }}"
+          echo "  Slug URL                : ${{ env.ANOTHER_VARIABLE_SLUG_URL }}"
+          echo "  Slug Case-Sensitive     : ${{ env.ANOTHER_VARIABLE_SLUG_CS }}"
+          echo "  Slug URL Case-Sensitive : ${{ env.ANOTHER_VARIABLE_SLUG_URL_CS }}"
+
+  custom_short:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rlespinasse/github-slug-action@v3.x
+        with:
+          custom_shorts: "SOME_VARIABLE,ANOTHER_VARIABLE"
+        env:
+          SOME_VARIABLE: Some Value
+          ANOTHER_VARIABLE: Another Value
+      - run: |
+          echo "SOME_VARIABLE"
+          echo "  Short : ${{ env.SOME_VARIABLE_SHORT }}"
+          echo "ANOTHER_VARIABLE"
+          echo "  Short : ${{ env.ANOTHER_VARIABLE_SHORT }}"


### PR DESCRIPTION
The needs of #68 is address by adding new input to this action and generate slug/shorts versions of input variables

```yaml
- uses: rlespinasse/github-slug-action@v3.x
   with:
     custom_slugs: "SOME_SLUG_VARIABLE,ANOTHER_SLUG_VARIABLE"
     custom_shorts: "SOME_SLUG_VARIABLE,ANOTHER_SLUG_VARIABLE"
```
    
- [x] Write contact (`action.yaml`)
- [x] Write documentation
- [x] Write examples
- [ ] Implementation and Tests

Resolves #68 