### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   analyse:
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     name: analyze
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   lint:
+    permissions:
+      actions: write
+      contents: read
+      statuses: write
     name: Lint
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      actions: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/auto-cancel-redundant-workflow@v1


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

I am the founder of [Step Security](https://www.stepsecurity.io), and have implemented a [GitHub App](https://github.com/apps/step-security) to automatically restrict permissions for the GITHUB_TOKEN in workflows. This is a security best practice as per the GitHub Actions [hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions). 

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. The App automatically fixes permissions when a new PR is created that creates a new workflow, so feel free to [install it](https://github.com/apps/step-security) for future workflows, or try it out on other repos. 

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. If you have feedback, would love to hear it. Unfortunately, the other workflows could not be fixed, since they use your action as a local action (./) which is not supported as of now. Thanks!