### PR TITLE
feat: add option to set a different short length than git defaults

### DIFF
--- a/.github/workflows/github-slug-action.yml
+++ b/.github/workflows/github-slug-action.yml
@@ -16,6 +16,7 @@ jobs:
         uses: ./
         with:
           prefix: V4_
+          short-length: 8
       - name: Validate // Partial variables
         run: |
           echo "repository owner : ${{ env.V4_GITHUB_REPOSITORY_OWNER_PART }}"
@@ -123,58 +124,94 @@ jobs:
         uses: actions/checkout@v3
 
       # Test 1
-      - name: Using correct max length
+      - name: Using correct slug max length
         uses: ./
         with:
           prefix: "CML_"
           slug-maxlength: 1
-      - name: Using correct max length // Validate that all slug variables are equals or under the slug-maxlength
+      - name: Using correct max length // Validate that all slug variables lengths are equals or under the slug-maxlength
         run: |
           env | grep "CML_" | grep "_SLUG" | cut -d"=" -f2 | while read -r value; do [ "$(echo "$value" | wc -m)" -le 2 ] ; done
         shell: bash
 
       # Test 2
-      - name: Using wrong max length
-        id: using-wrong-max-length
+      - name: Using wrong slug max length
+        id: using-wrong-slug-max-length
         uses: ./
         with:
           prefix: "WML_"
           slug-maxlength: "wrong"
         continue-on-error: true
-      - name: Using wrong max length // Validate that the action end with an error
+      - name: Using wrong slug max length // Validate that the action end with an error
         run: |
           [[ "$(env | grep "WML_" | grep "_SLUG" | wc -l)" -eq 0 ]]
-          [[ "${{ steps.using-wrong-max-length.outcome }}" == "failure" ]]
-          [[ "${{ steps.using-wrong-max-length.conclusion }}" == "success" ]]
+          [[ "${{ steps.using-wrong-slug-max-length.outcome }}" == "failure" ]]
+          [[ "${{ steps.using-wrong-slug-max-length.conclusion }}" == "success" ]]
         shell: bash
 
       # Test 3
-      - name: Using empty max length
-        id: using-empty-max-length
+      - name: Using empty slug max length
+        id: using-empty-slug-max-length
         uses: ./
         with:
           prefix: "EML_"
           slug-maxlength: ""
         continue-on-error: true
-      - name: Using empty max length // Validate that the action end with an error
+      - name: Using empty slug max length // Validate that the action end with an error
         run: |
           [[ "$(env | grep "EML_" | grep "_SLUG" | wc -l)" -eq 0 ]]
-          [[ "${{ steps.using-empty-max-length.outcome }}" == "failure" ]]
-          [[ "${{ steps.using-empty-max-length.conclusion }}" == "success" ]]
+          [[ "${{ steps.using-empty-slug-max-length.outcome }}" == "failure" ]]
+          [[ "${{ steps.using-empty-slug-max-length.conclusion }}" == "success" ]]
         shell: bash
 
       # Test 4
-      - name: Using no limit on max length
-        id: using-nolimit-max-length
+      - name: Using no limit on slug max length
+        id: using-nolimit-slug-max-length
         uses: ./
         with:
           prefix: "NLML_"
           slug-maxlength: "nolimit"
-      - name: Using no limit on length // Validate that the action end with an error
+      - name: Using no limit on slug max length // Validate that the action end with an error
         run: |
           [[ "$(env | grep "NLML_" | grep "_SLUG" | wc -l)" -gt 0 ]]
-          [[ "${{ steps.using-nolimit-max-length.outcome }}" == "success" ]]
-          [[ "${{ steps.using-nolimit-max-length.conclusion }}" == "success" ]]
+          [[ "${{ steps.using-nolimit-slug-max-length.outcome }}" == "success" ]]
+          [[ "${{ steps.using-nolimit-slug-max-length.conclusion }}" == "success" ]]
+        shell: bash
+
+  os-testing-short-length:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Test 1
+      - name: Using correct short length
+        uses: ./
+        with:
+          prefix: "CSL_"
+          short-length: 4
+      - name: Using correct length // Validate that all short variables lengths are equals to short-length
+        run: |
+          env | grep "CSL_" | grep "_SHORT" | cut -d"=" -f2 | while read -r value; do [ "$(echo "$value" | wc -m)" -le 5 ] ; done
+        shell: bash
+
+      # Test 2
+      - name: Using wrong short length
+        id: using-wrong-short-length
+        uses: ./
+        with:
+          prefix: "WSL_"
+          short-length: "wrong"
+        continue-on-error: true
+      - name: Using wrong short length // Validate that the action end with an error
+        run: |
+          [[ "$(env | grep "WSL_" | grep "_SHORT" | wc -l)" -eq 0 ]]
+          [[ "${{ steps.using-wrong-short-length.outcome }}" == "failure" ]]
+          [[ "${{ steps.using-wrong-short-length.conclusion }}" == "success" ]]
         shell: bash
 
   os-testing-without-checkout:
@@ -195,6 +232,7 @@ jobs:
         uses: ./this-action
         with:
           prefix: V4_
+          short-length: 8
       - name: Validate // Short SHA variables
         run: |
           echo "sha              : ${{ env.V4_GITHUB_SHA_SHORT }}"
@@ -210,6 +248,7 @@ jobs:
     needs:
       - os-testing
       - os-testing-slug-maxlength
+      - os-testing-short-length
       - os-testing-without-checkout
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Use this action](#use-this-action)
+    - [Migration from previous versions](#migration-from-previous-versions)
   - [Available Environment variables](#available-environment-variables)
     - [Enhanced variables](#enhanced-variables)
     - [Partial variables](#partial-variables)
@@ -19,6 +20,7 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
     - [Slug URL variables](#slug-url-variables)
     - [Short variables](#short-variables)
   - [Troubleshooting](#troubleshooting)
+    - [The SHORT variables doesn't have the same lengths as before](#the-short-variables-doesnt-have-the-same-lengths-as-before)
     - [One of the environment variables doesn't work as intended](#one-of-the-environment-variables-doesnt-work-as-intended)
     - [An action could not be found at the URI](#an-action-could-not-be-found-at-the-uri)
   - [Thanks for talking about us](#thanks-for-talking-about-us)
@@ -59,27 +61,56 @@ Add this in your workflow
   uses: rlespinasse/github-slug-action@v4
 ```
 
-Or with a prefix
+Others configurations
 
-```yaml
-- name: Inject slug/short variables
-  uses: rlespinasse/github-slug-action@v4
-  with:
-    prefix: CI_
-```
+- With a prefix
 
-Or with another max length for slug values
+  ```yaml
+  - name: Inject slug/short variables
+    uses: rlespinasse/github-slug-action@v4
+    with:
+      prefix: CI_
+  ```
 
-```yaml
-- name: Inject slug/short variables
-  uses: rlespinasse/github-slug-action@v4
-  with:
-    slug-maxlength: 80 # use 'nolimit' to remove use of a max length
-```
+- With another max length for slug values
+
+  ```yaml
+  - name: Inject slug/short variables
+    uses: rlespinasse/github-slug-action@v4
+    with:
+      slug-maxlength: 80 # Use 'nolimit' to remove use of a max length (Default to 63)
+  ```
+
+- With another length for short values
+
+  ```yaml
+  - name: Inject slug/short variables
+    uses: rlespinasse/github-slug-action@v4
+    with:
+      short-length: 7 # By default it's up to git to decide, use 8 to have the v3.x behavior
+  ```
+
+  **Warning**: If you leave it empty, you need to checkout the source first in order to let git decide the size by itself.
 
 Check for more [examples][examples] (OS usage, URL use, ...)
 
 **Tip:** Use [Dependabot][dependabot] to maintain your `github-slug-action` version updated in your GitHub workflows.
+
+### Migration from previous versions
+
+The short sha length is not the same as previous version.
+
+- `v4` let git configuration decide of it (but you can override it),
+- `v3` and before, it's always a length of 8 characters.
+
+So to reproduce previous behavior, use
+
+```yaml
+- name: Inject slug/short variables
+  uses: rlespinasse/github-slug-action@v4
+  with:
+    short-length: 8 # Same as v3 and before
+```
 
 ## Available Environment variables
 
@@ -136,6 +167,18 @@ Check for more [examples][examples] (OS usage, URL use, ...)
 | [GITHUB_EVENT<br>_PULL_REQUEST<br>_HEAD_SHA_SHORT](docs/short-variables.md#github_event_pull_request_head_sha_short) | _github.event<br>.pull_request<br>.head.sha_ | The commit SHA on pull request that trigger workflow.<br>Only set for [following webhook events][webhooks-and-events]<ul><li>`pull_request`</li><li>`pull_request_review`</li><li>`pull_request_review_comment`</li><li>`pull_request_target`</li></ul> |
 
 ## Troubleshooting
+
+### The SHORT variables doesn't have the same lengths as before
+
+Since `v4`, it's git who manage the short variables by using [git rev-parse][git-revparse] behaviour.
+The length of a short sha depends of the size of our repository and can differ over time.
+
+To manage that moving length, you can use `short-length` input
+
+- set `7` to reproduce `small repository` behavior
+- set `8` to reproduce `v3` behavior
+
+**Warning**: The minimum length is 4, the default is the effective value of the [core.abbrev][git-core-abbrev] configuration variable.
 
 ### One of the environment variables doesn't work as intended
 
@@ -201,6 +244,9 @@ Please, use the current major tag `v4` or a version tag (see [releases pages][re
 [custom-variable]: https://github.com/rlespinasse/github-slug-action/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=
 [releases]: https://github.com/rlespinasse/github-slug-action/releases
 [issue-15]: https://github.com/rlespinasse/github-slug-action/issues/15
+
+[git-revpars]: https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength
+[git-core-abbrev]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev
 
 [github-env-vars]: https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 [dependabot]: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: "Max length of the slugified values"
     default: "63"
     required: true
+  short-length:
+    description: "Length of the shortify values (git default if empty)"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -20,6 +23,7 @@ runs:
       shell: bash
       env:
         INPUT_SLUG_MAXLENGTH: ${{ inputs.slug-maxlength }}
+        INPUT_SHORT_LENGTH: ${{ inputs.short-length }}
 
     - uses: rlespinasse/slugify-value@v1.2.0
       with:
@@ -85,12 +89,12 @@ runs:
       with:
         name: GITHUB_SHA
         short-on-error: true
-        length: 8
+        length: ${{ inputs.short-length }}
         prefix: ${{ inputs.prefix }}
     - uses: rlespinasse/shortify-git-revision@v1.4.0
       with:
         name: GITHUB_EVENT_PULL_REQUEST_HEAD_SHA
         revision: ${{ github.event.pull_request.head.sha }}
         short-on-error: true
-        length: 8
+        length: ${{ inputs.short-length }}
         prefix: ${{ inputs.prefix }}

--- a/preflight.sh
+++ b/preflight.sh
@@ -7,3 +7,8 @@ elif [ "${INPUT_SLUG_MAXLENGTH}" != "nolimit" ] && [ ! "${INPUT_SLUG_MAXLENGTH}"
   echo "::error ::slug-maxlength must be a number or equals to 'nolimit'"
   exit 1
 fi
+
+if [ ! "${INPUT_SHORT_LENGTH}" -eq "${INPUT_SHORT_LENGTH}" ] 2>/dev/null; then
+  echo "::error ::short-length must be a number"
+  exit 1
+fi


### PR DESCRIPTION
- Revert to 4.0.0 behavior, but add `short-length` input to reproduce `v3` behavior.
- Add documentation to migrate from `v3` to `v4`.
- Add troubleshooting about a change of short values length.

Resolves #92 