### PR TITLE
fix: set short-length automatically when no checkout

### DIFF
--- a/.github/workflows/github-slug-action.yml
+++ b/.github/workflows/github-slug-action.yml
@@ -241,6 +241,59 @@ jobs:
           [[ "${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT }}" == "${{ env.V4_GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT }}" ]]
         shell: bash
 
+  os-testing-short-length-without-checkout:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: this-action
+          ref: ${{ github.ref }}
+
+      # Test 1
+      - name: Using correct short length
+        uses: ./this-action
+        with:
+          prefix: "CSL_"
+          short-length: 4
+      - name: Using correct length // Validate that all short variables lengths are equals to short-length
+        run: |
+          env | grep "CSL_" | grep "_SHORT" | cut -d"=" -f2 | while read -r value; do [ "$(echo "$value" | wc -m)" -le 5 ] ; done
+        shell: bash
+
+      # Test 2
+      - name: Using empty short length
+        id: using-empty-short-length
+        uses: ./this-action
+        with:
+          prefix: "ESL_"
+        continue-on-error: true
+      - name: Using empty short length // Validate that the action don't end with an error
+        run: |
+          [[ "$(env | grep "ESL_" | grep "_SHORT" | wc -l)" -gt 0 ]]
+          [[ "${{ steps.using-empty-short-length.outcome }}" == "success" ]]
+          [[ "${{ steps.using-empty-short-length.conclusion }}" == "success" ]]
+        shell: bash
+
+      # Test 3
+      - name: Using wrong short length
+        id: using-wrong-short-length
+        uses: ./this-action
+        with:
+          prefix: "WSL_"
+          short-length: "wrong"
+        continue-on-error: true
+      - name: Using wrong short length // Validate that the action end with an error
+        run: |
+          [[ "$(env | grep "WSL_" | grep "_SHORT" | wc -l)" -eq 0 ]]
+          [[ "${{ steps.using-wrong-short-length.outcome }}" == "failure" ]]
+          [[ "${{ steps.using-wrong-short-length.conclusion }}" == "success" ]]
+        shell: bash
+
   release:
     runs-on: ubuntu-latest
     concurrency:
@@ -250,6 +303,7 @@ jobs:
       - os-testing-slug-maxlength
       - os-testing-short-length
       - os-testing-without-checkout
+      - os-testing-short-length-without-checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ runs:
   using: "composite"
   steps:
     - run: $GITHUB_ACTION_PATH/preflight.sh
+      id: prefligth
       shell: bash
       env:
         INPUT_SLUG_MAXLENGTH: ${{ inputs.slug-maxlength }}
@@ -89,12 +90,12 @@ runs:
       with:
         name: GITHUB_SHA
         short-on-error: true
-        length: ${{ inputs.short-length }}
+        length: ${{ steps.prefligth.outputs.PREFLIGHT_SHORT_LENGTH }}
         prefix: ${{ inputs.prefix }}
     - uses: rlespinasse/shortify-git-revision@v1.4.0
       with:
         name: GITHUB_EVENT_PULL_REQUEST_HEAD_SHA
         revision: ${{ github.event.pull_request.head.sha }}
         short-on-error: true
-        length: ${{ inputs.short-length }}
+        length: ${{ steps.prefligth.outputs.PREFLIGHT_SHORT_LENGTH }}
         prefix: ${{ inputs.prefix }}

--- a/preflight.sh
+++ b/preflight.sh
@@ -12,3 +12,23 @@ if [ ! "${INPUT_SHORT_LENGTH}" -eq "${INPUT_SHORT_LENGTH}" ] 2>/dev/null; then
   echo "::error ::short-length must be a number"
   exit 1
 fi
+
+echo "::debug ::Control preflight short-length setup"
+PREFLIGHT_SHORT_LENGTH=""
+if [ -n "${INPUT_SHORT_LENGTH}" ]; then
+  PREFLIGHT_SHORT_LENGTH="${INPUT_SHORT_LENGTH}"
+  echo "::debug ::Use input value: $PREFLIGHT_SHORT_LENGTH"
+elif [ "$(git rev-parse --is-inside-work-tree)" == "true" ]; then
+  echo "::debug ::The action run inside a git repository, short-length can be empty"
+else
+  echo "::debug ::The action run outside a git repository, need to set short-length"
+  PREFLIGHT_SHORT_LENGTH="$(git config --get core.abbrev)"
+  if [ -n "${PREFLIGHT_SHORT_LENGTH}" ]; then
+    echo "::debug ::Git Configuration 'core.abbrev' is set, using it as short-length"
+  else
+    PREFLIGHT_SHORT_LENGTH="7"
+    echo "::debug ::Using fallback value for short-length"
+  fi
+fi
+echo "::debug ::Set PREFLIGHT_SHORT_LENGTH=$PREFLIGHT_SHORT_LENGTH"
+echo "::set-output name=PREFLIGHT_SHORT_LENGTH::$PREFLIGHT_SHORT_LENGTH"


### PR DESCRIPTION
- Add test cases to reproduce #95 
- Preflight script setup a default short length only when there is no source checkout

Resolves #95 