### PR TITLE
Update slugify-value to 1.3.3 + shortify-git-revision to 1.5.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,30 +26,30 @@ runs:
         INPUT_SLUG_MAXLENGTH: ${{ inputs.slug-maxlength }}
         INPUT_SHORT_LENGTH: ${{ inputs.short-length }}
 
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_REPOSITORY
         value: ${{ github.repository }}
         prefix: ${{ inputs.prefix }}
         slug-maxlength: ${{ inputs.slug-maxlength }}
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_REF
         prefix: ${{ inputs.prefix }}
         slug-maxlength: ${{ inputs.slug-maxlength }}
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_HEAD_REF
         prefix: ${{ inputs.prefix }}
         slug-maxlength: ${{ inputs.slug-maxlength }}
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_BASE_REF
         prefix: ${{ inputs.prefix }}
         slug-maxlength: ${{ inputs.slug-maxlength }}
 
     # Specific values
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_EVENT_REF
         value: ${{ github.event.ref }}
@@ -60,7 +60,7 @@ runs:
     - id: get-github-ref-name
       run: echo "github-ref-name=${{ github.head_ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
       shell: bash
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_REF_NAME
         value: ${{ steps.get-github-ref-name.outputs.github-ref-name }}
@@ -69,7 +69,7 @@ runs:
     - id: get-github-repository-owner-part
       run: echo "github-repository-owner-part=$(echo $GITHUB_REPOSITORY | cut -d/ -f1)" >> "$GITHUB_OUTPUT"
       shell: bash
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_REPOSITORY_OWNER_PART
         value: ${{ steps.get-github-repository-owner-part.outputs.github-repository-owner-part }}
@@ -78,7 +78,7 @@ runs:
     - id: get-github-repository-name-part
       run: echo "github-repository-name-part=$(echo $GITHUB_REPOSITORY | cut -d/ -f2)" >> "$GITHUB_OUTPUT"
       shell: bash
-    - uses: rlespinasse/slugify-value@v1.3.2
+    - uses: rlespinasse/slugify-value@v1.3.3
       with:
         key: GITHUB_REPOSITORY_NAME_PART
         value: ${{ steps.get-github-repository-name-part.outputs.github-repository-name-part }}

--- a/action.yml
+++ b/action.yml
@@ -86,13 +86,13 @@ runs:
         slug-maxlength: ${{ inputs.slug-maxlength }}
 
     # Short
-    - uses: rlespinasse/shortify-git-revision@v1.4.0
+    - uses: rlespinasse/shortify-git-revision@v1.5.1
       with:
         name: GITHUB_SHA
         short-on-error: true
         length: ${{ steps.prefligth.outputs.PREFLIGHT_SHORT_LENGTH }}
         prefix: ${{ inputs.prefix }}
-    - uses: rlespinasse/shortify-git-revision@v1.4.0
+    - uses: rlespinasse/shortify-git-revision@v1.5.1
       with:
         name: GITHUB_EVENT_PULL_REQUEST_HEAD_SHA
         revision: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Just updating the dependencies to your sub repository to remove the `set-output` warnings