### PR TITLE
feat: use GITHUB_REF_POINT as variable for the branch name

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,7 @@ jobs:
         uses: github/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false
           DEFAULT_BRANCH: v5.x

--- a/.github/workflows/v5-tests-and-release.yml
+++ b/.github/workflows/v5-tests-and-release.yml
@@ -68,7 +68,7 @@ jobs:
           [[ "${{ env.GITHUB_EVENT_REF_SLUG_URL_CS }}" == "${{ env.V4_GITHUB_EVENT_REF_SLUG_URL_CS }}" ]]
         shell: bash
 
-      - name: Validate // Ref Name
+      - name: Validate // Ref Point
         run: |
           [[ "${{ env.GITHUB_REF_POINT }}" == "${{ env.V4_GITHUB_REF_NAME }}" ]]
           [[ "${{ env.GITHUB_REF_POINT_SLUG }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG }}" ]]

--- a/.github/workflows/v5-tests-and-release.yml
+++ b/.github/workflows/v5-tests-and-release.yml
@@ -139,6 +139,7 @@ jobs:
           echo "repository owner : ${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}"
           echo "repository name  : ${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}"
           echo "ref              : ${{ env.GITHUB_REF_SLUG }}"
+          echo "ref name         : ${{ env.GITHUB_REF_NAME_SLUG }}"
           echo "head ref         : ${{ env.GITHUB_HEAD_REF_SLUG }}"
           echo "base ref         : ${{ env.GITHUB_BASE_REF_SLUG }}"
           echo "event ref        : ${{ env.GITHUB_EVENT_REF_SLUG }}"
@@ -150,6 +151,7 @@ jobs:
           echo "repository owner : ${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG_CS }}"
           echo "repository name  : ${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG_CS }}"
           echo "ref              : ${{ env.GITHUB_REF_SLUG_CS }}"
+          echo "ref name         : ${{ env.GITHUB_REF_NAME_SLUG_CS }}"
           echo "head ref         : ${{ env.GITHUB_HEAD_REF_SLUG_CS }}"
           echo "base ref         : ${{ env.GITHUB_BASE_REF_SLUG_CS }}"
           echo "event ref        : ${{ env.GITHUB_EVENT_REF_SLUG_CS }}"
@@ -161,6 +163,7 @@ jobs:
           echo "repository owner : ${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG_URL }}"
           echo "repository name  : ${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG_URL }}"
           echo "ref              : ${{ env.GITHUB_REF_SLUG_URL }}"
+          echo "ref name         : ${{ env.GITHUB_REF_NAME_SLUG_URL }}"
           echo "head ref         : ${{ env.GITHUB_HEAD_REF_SLUG_URL }}"
           echo "base ref         : ${{ env.GITHUB_BASE_REF_SLUG_URL }}"
           echo "event ref        : ${{ env.GITHUB_EVENT_REF_SLUG_URL }}"
@@ -172,12 +175,13 @@ jobs:
           echo "repository owner : ${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG_URL_CS }}"
           echo "repository name  : ${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG_URL_CS }}"
           echo "ref              : ${{ env.GITHUB_REF_SLUG_URL_CS }}"
+          echo "ref name         : ${{ env.GITHUB_REF_NAME_SLUG_URL_CS }}"
           echo "head ref         : ${{ env.GITHUB_HEAD_REF_SLUG_URL_CS }}"
           echo "base ref         : ${{ env.GITHUB_BASE_REF_SLUG_URL_CS }}"
           echo "event ref        : ${{ env.GITHUB_EVENT_REF_SLUG_URL_CS }}"
         shell: bash
 
-      - name: Ref Name
+      - name: Ref Point
         run: |
           echo "raw                       : ${{ env.GITHUB_REF_POINT }}"
           echo "slug                      : ${{ env.GITHUB_REF_POINT_SLUG }}"

--- a/.github/workflows/v5-tests-and-release.yml
+++ b/.github/workflows/v5-tests-and-release.yml
@@ -70,11 +70,11 @@ jobs:
 
       - name: Validate // Ref Name
         run: |
-          [[ "${{ env.GITHUB_REF_NAME }}" == "${{ env.V4_GITHUB_REF_NAME }}" ]]
-          [[ "${{ env.GITHUB_REF_NAME_SLUG }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG }}" ]]
-          [[ "${{ env.GITHUB_REF_NAME_SLUG_URL }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG_URL }}" ]]
-          [[ "${{ env.GITHUB_REF_NAME_SLUG_CS }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG_CS }}" ]]
-          [[ "${{ env.GITHUB_REF_NAME_SLUG_URL_CS }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG_URL_CS }}" ]]
+          [[ "${{ env.GITHUB_REF_POINT }}" == "${{ env.V4_GITHUB_REF_NAME }}" ]]
+          [[ "${{ env.GITHUB_REF_POINT_SLUG }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG }}" ]]
+          [[ "${{ env.GITHUB_REF_POINT_SLUG_URL }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG_URL }}" ]]
+          [[ "${{ env.GITHUB_REF_POINT_SLUG_CS }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG_CS }}" ]]
+          [[ "${{ env.GITHUB_REF_POINT_SLUG_URL_CS }}" == "${{ env.V4_GITHUB_REF_NAME_SLUG_URL_CS }}" ]]
         shell: bash
 
       - name: Validate // Short SHA variables
@@ -179,11 +179,11 @@ jobs:
 
       - name: Ref Name
         run: |
-          echo "raw                       : ${{ env.GITHUB_REF_NAME }}"
-          echo "slug                      : ${{ env.GITHUB_REF_NAME_SLUG }}"
-          echo "slug url                  : ${{ env.GITHUB_REF_NAME_SLUG_URL }}"
-          echo "slug (Case Sensitive)     : ${{ env.GITHUB_REF_NAME_SLUG_CS }}"
-          echo "slug url (Case Sensitive) : ${{ env.GITHUB_REF_NAME_SLUG_URL_CS }}"
+          echo "raw                       : ${{ env.GITHUB_REF_POINT }}"
+          echo "slug                      : ${{ env.GITHUB_REF_POINT_SLUG }}"
+          echo "slug url                  : ${{ env.GITHUB_REF_POINT_SLUG_URL }}"
+          echo "slug (Case Sensitive)     : ${{ env.GITHUB_REF_POINT_SLUG_CS }}"
+          echo "slug url (Case Sensitive) : ${{ env.GITHUB_REF_POINT_SLUG_URL_CS }}"
         shell: bash
 
       - name: Short SHA variables

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ steps:
 
 ### Partial variables
 
-| Variable | Partial version of | Description |
-| -------- | ------------------ | ----------- |
-| [GITHUB_REPOSITORY_OWNER_PART](docs/partial-variables.md#github_repository_owner_part) | GITHUB_REPOSITORY | The Owner part of GITHUB_REPOSITORY variable |
-| [GITHUB_REPOSITORY_NAME_PART](docs/partial-variables.md#github_repository_name_part) | GITHUB_REPOSITORY | The Repository name part of GITHUB_REPOSITORY variable |
+| Variable | Description |
+| -------- | ----------- |
+| [GITHUB_REPOSITORY_OWNER_PART](docs/partial-variables.md#github_repository_owner_part) | The Owner part of GITHUB_REPOSITORY variable |
+| [GITHUB_REPOSITORY_NAME_PART](docs/partial-variables.md#github_repository_name_part) | The Repository name part of GITHUB_REPOSITORY variable |
 
 ### Slug variables
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ steps:
 ### Slug variables
 
 > [!TIP]
-> `_CS` suffix also available for Case-Sensitive preservation
+> Available in standard and case-sensitive (`_CS`) versions.
 
 | Variable | Description |
 | -------- | ----------- |
@@ -114,10 +114,12 @@ steps:
 | [GITHUB_BASE_REF_SLUG](docs/slug-variables.md#github_base_ref_slug) | The branch of the base repository. |
 | [GITHUB_EVENT_REF_SLUG](docs/slug-variables.md#github_event_ref_slug) | The Git reference resource associated to triggered webhook. |
 
-### Slug URL variables
+### URL-Safe Slug variables
+
+Same as slug variables but URL-compliant
 
 > [!TIP]
-> `_CS` suffix also available for Case-Sensitive preservation
+> Available in standard and case-sensitive (`_CS`) versions.
 
 | Variable | Description |
 | -------- | ----------- |
@@ -139,7 +141,7 @@ steps:
 
 ## Migration from previous versions
 
-### From v4
+### v4 to v5
 
 The **GITHUB_REF_NAME SLUG/SLUG_URL** variables doesn't work the same way as before
 
@@ -167,7 +169,7 @@ steps:
 Then `${{ env.GITHUB_REF_POINT }}`, and `$GITHUB_REF_POINT` will serve the behavior of this action.
 And `${{ env.GITHUB_REF_NAME }}`, and `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
 
-### From v3
+### v3 to v4
 
 Since `v4`, it's Git who manage the short variables by using [`git rev-parse`][git-revparse] behaviour.
 The length of a short sha depends of the size of our repository and can differ over time.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
 - `<VAR>_CS` on others variables to keep the value case-sensitive
   - Like `GITHUB_REF_SLUG_CS`
 
-## Use this action
+## Installation
 
-Add this in your workflow, or check for more [examples][examples] (OS usage, URL use, ...)
+Add this step to your workflow
 
 ```yaml
 steps:
@@ -33,8 +33,13 @@ steps:
     uses: rlespinasse/github-slug-action@v5
 ```
 
-> [!TIP]
+> [!CAUTION]
 > Use [Dependabot][dependabot] to maintain your `github-slug-action` version updated in your GitHub workflows.
+
+## Configuration Options
+
+> [!TIP]
+> Check for more [examples][examples] (OS usage, URL use, ...)
 
 ### With a prefix
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ So to reproduce previous behavior, use
 | [GITHUB_REPOSITORY<br>_NAME_PART_SLUG_URL](docs/slug-variables.md#github_repository_name_part_slug_url) | GITHUB_REPOSITORY_NAME_PART | The repository name. |
 | [GITHUB_REF_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | GITHUB_REF | The branch or tag ref that triggered the workflow. |
 | [GITHUB_REF_NAME_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | GITHUB_REF_NAME | This value matches the branch or tag name shown on GitHub. Similar to GITHUB_REF_SLUG_URL. |
-| [GITHUB_HEAD_REF_SLUG_URL](docs/slug-url-variables.md#github_head_ref_slug_url) | GITHUB_HEAD_REF | The branch of the head repository.<br>Only set for [pull-request][webhooks-and-events] event and forked repositories. |
-| [GITHUB_BASE_REF_SLUG_URL](docs/slug-url-variables.md#github_base_ref_slug_url) | GITHUB_BASE_REF | The branch of the base repository.<br>Only set for [pull-request][webhooks-and-events] event and forked repositories. |
+| [GITHUB_HEAD_REF_SLUG_URL](docs/slug-url-variables.md#github_head_ref_slug_url) | GITHUB_HEAD_REF | The branch of the head repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
+| [GITHUB_BASE_REF_SLUG_URL](docs/slug-url-variables.md#github_base_ref_slug_url) | GITHUB_BASE_REF | The branch of the base repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
 | [GITHUB_EVENT_REF_SLUG_URL](docs/slug-url-variables.md#github_event_ref_slug_url) | _github.event.ref_ | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul> |
 
 ### Short variables
@@ -177,7 +177,7 @@ So to reproduce previous behavior, use
 
 ### The SHORT variables doesn't have the same lengths as before
 
-Since `v4`, it's Git who manage the short variables by using [git rev-parse][git-revparse] behaviour.
+Since `v4`, it's Git who manage the short variables by using [`git rev-parse`][git-revparse] behaviour.
 The length of a short sha depends of the size of our repository and can differ over time.
 
 To manage that moving length, you can use `short-length` input
@@ -279,6 +279,7 @@ In Chinese :cn:
 [default-environment-variables]: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 [dependabot]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
 [webhooks-and-events]: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads
+[event-pull-request]: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
 [naming-conventions]: https://docs.github.com/en/actions/reference/environment-variables#naming-conventions-for-environment-variables
 
 [article-1]: https://esensconsulting.medium.com/mettre-en-place-une-ci-cd-angular-avec-github-actions-netlify-ca0b59b99ed8

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Additional enhanced environment variables can be compute to help you around GitH
 Add this in your workflow
 
 ```yaml
-- name: Inject slug/short variables
+- name: Inject enhanced GitHub environment variables
   uses: rlespinasse/github-slug-action@v5
 ```
 
@@ -66,7 +66,7 @@ Add this in your workflow
 - With a prefix
 
   ```yaml
-  - name: Inject slug/short variables
+  - name: Inject enhanced GitHub environment variables
     uses: rlespinasse/github-slug-action@v5
     with:
       prefix: CI_
@@ -75,7 +75,7 @@ Add this in your workflow
 - With another max length for slug values
 
   ```yaml
-  - name: Inject slug/short variables
+  - name: Inject enhanced GitHub environment variables
     uses: rlespinasse/github-slug-action@v5
     with:
       slug-maxlength: 80 # Use 'nolimit' to remove use of a max length (Default to 63)
@@ -84,7 +84,7 @@ Add this in your workflow
 - With another length for short values
 
   ```yaml
-  - name: Inject slug/short variables
+  - name: Inject enhanced GitHub environment variables
     uses: rlespinasse/github-slug-action@v5
     with:
       short-length: 7 # By default it's up to Git to decide, use 8 to have the v3.x behavior
@@ -108,7 +108,7 @@ The short sha length is not the same as previous version.
 So to reproduce previous behavior, use
 
 ```yaml
-- name: Inject slug/short variables
+- name: Inject enhanced GitHub environment variables
   uses: rlespinasse/github-slug-action@v5
   with:
     short-length: 8 # Same as v3 and before
@@ -116,15 +116,17 @@ So to reproduce previous behavior, use
 
 ## Available Environment variables
 
-**Note**: If you don't find what you search for, read more about [available `GitHub` variables](docs/github-variables.md), and propose a [new custom variable][custom-variable].
+> [!NOTE]
+> If you don't find what you search for, read more about [available `GitHub` variables](docs/github-variables.md), and propose a [new custom variable][custom-variable].
 
 ### Enhanced variables
 
-- `GITHUB_REF_NAME` will contains the reference name (branch or tag)
+- `GITHUB_REF_POINT` will contains the reference name (branch or tag)
   - based on `GITHUB_HEAD_REF` in a [`pull-request*`][webhooks-and-events] event context,
   - based on `GITHUB_REF` in others event context.
 
-**NOTE:** All enhanced variables are available in all **slug** formats.
+> [!NOTE]
+> All enhanced variables are available in all **slug** formats.
 
 ### Partial variables
 
@@ -135,7 +137,8 @@ So to reproduce previous behavior, use
 
 ### Slug variables
 
-**NOTE:** `_CS` suffix available
+> [!TIP]
+> `_CS` suffix also available
 
 | Variable                                                                                          | Slug version of              | Description                                                                                                          |
 | ------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -149,7 +152,8 @@ So to reproduce previous behavior, use
 
 ### Slug URL variables
 
-**NOTE:** `_CS` suffix available
+> [!TIP]
+> `_CS` suffix also available
 
 | Variable                                                                                                  | Slug URL version of          | Description                                                                                                           |
 | --------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
@@ -184,7 +188,8 @@ To manage that moving length, you can use `short-length` input
 
 ### One of the environment variables doesn't work as intended
 
-[**Note**][naming-conventions]: When you set a custom environment variable, you cannot use any of the default environment variable names. For a complete list of these, see [Default environment variables][default-environment-variables]. **If you attempt to override the value of one of these default environment variables, the assignment is ignored.**
+> [!WARNING]
+> When you set a custom environment variable, you [cannot use any of the default environment variable names][naming-conventions]. For a complete list of these, see [Default environment variables][default-environment-variables]. **If you attempt to override the value of one of these default environment variables, the assignment is ignored.**
 
 If a variable start to be used as default environment variable, the environment variable may have a different behavior than the expected one.
 
@@ -196,13 +201,16 @@ If this append, the `${{ env.GITHUB_AWESOME_VARIABLE }}` and `$GITHUB_AWESOME_VA
 Otherwise the two expression will serve the behavior of this action.
 This will not occurs if you use the `prefix` input to avoid the issue.
 
-**NOTE:** If detected, the maintainers of this action will choose the best course of action depending of the impact.
+> [!IMPORTANT]
+> If detected, the maintainers of this action will choose the best course of action depending of the impact.
 
 #### Known environment variable conflicts
 
 ##### GITHUB_REF_NAME
 
-The behavior is the same as the GitHub one except on `pull_request*` workflows ([Ready the full story][issue-104]).
+If you use `v5` or related versions, you need to use `GITHUB_REF_POINT` instead of `GITHUB_REF_NAME`.
+
+Before `v5`, the behavior is the same as the GitHub one except on `pull_request*` workflows ([Ready the full story][issue-104]).
 
 - `${{ env.GITHUB_REF_NAME }}` will serve the behavior of this action,
 - `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
@@ -212,10 +220,26 @@ On `pull_request*` workflows, the content will be `<PR-number>/merge` instead of
 A possible workaround is to use `prefix` input
 
 ```yaml
-- name: Inject slug/short variables
-  uses: rlespinasse/github-slug-action@v5
-  with:
-    prefix: CI_
+steps:
+  - name: Inject enhanced GitHub environment variables
+    uses: rlespinasse/github-slug-action@v4
+    with:
+      prefix: CI_
+  - run: |
+      echo "Branch Name: ${CI_GITHUB_REF_NAME}"
+    shell: bash
+```
+
+or to use `v5` and move to `GITHUB_REF_POINT`
+
+```yaml
+steps:
+  - name: Inject enhanced GitHub environment variables
+    uses: rlespinasse/github-slug-action@v5
+  - run: |
+      echo "Branch Name: ${GITHUB_REF_POINT}"
+    shell: bash
+
 ```
 
 Then `${{ env.CI_GITHUB_REF_NAME }}`, and `$CI_GITHUB_REF_NAME` will serve the behavior of this action.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
     - [Short variables](#short-variables)
   - [Troubleshooting](#troubleshooting)
     - [The SHORT variables doesn't have the same lengths as before](#the-short-variables-doesnt-have-the-same-lengths-as-before)
+    - [The GITHUB\_REF\_NAME SLUG/SLUG\_URL variables doesn't work the same way as before](#the-github_ref_name-slugslug_url-variables-doesnt-work-the-same-way-as-before)
     - [One of the environment variables doesn't work as intended](#one-of-the-environment-variables-doesnt-work-as-intended)
-      - [Known environment variable conflicts](#known-environment-variable-conflicts)
-        - [GITHUB\_REF\_NAME](#github_ref_name)
     - [An action could not be found at the URI](#an-action-could-not-be-found-at-the-uri)
   - [Thanks for talking about us](#thanks-for-talking-about-us)
 
@@ -123,53 +122,55 @@ So to reproduce previous behavior, use
 
 - `GITHUB_REF_POINT` will contains the reference name (branch or tag)
   - based on `GITHUB_HEAD_REF` in a [`pull-request*`][webhooks-and-events] event context,
-  - based on `GITHUB_REF` in others event context.
+  - based on `GITHUB_REF_NAME` in others event context.
 
 > [!NOTE]
 > All enhanced variables are available in all **slug** formats.
 
 ### Partial variables
 
-| Variable                                                                               | Partial version of | Description                                            |
-| -------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------ |
-| [GITHUB_REPOSITORY_OWNER_PART](docs/partial-variables.md#github_repository_owner_part) | GITHUB_REPOSITORY  | The Owner part of GITHUB_REPOSITORY variable           |
-| [GITHUB_REPOSITORY_NAME_PART](docs/partial-variables.md#github_repository_name_part)   | GITHUB_REPOSITORY  | The Repository name part of GITHUB_REPOSITORY variable |
+| Variable | Partial version of | Description |
+| -------- | ------------------ | ----------- |
+| [GITHUB_REPOSITORY_OWNER_PART](docs/partial-variables.md#github_repository_owner_part) | GITHUB_REPOSITORY | The Owner part of GITHUB_REPOSITORY variable |
+| [GITHUB_REPOSITORY_NAME_PART](docs/partial-variables.md#github_repository_name_part) | GITHUB_REPOSITORY | The Repository name part of GITHUB_REPOSITORY variable |
 
 ### Slug variables
 
 > [!TIP]
 > `_CS` suffix also available
 
-| Variable                                                                                          | Slug version of              | Description                                                                                                          |
-| ------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| [GITHUB_REPOSITORY_SLUG](docs/slug-variables.md#github_repository_slug)                           | GITHUB_REPOSITORY            | The owner and repository name.                                                                                       |
-| [GITHUB_REPOSITORY<br>_OWNER_PART_SLUG](docs/slug-variables.md#github_repository_owner_part_slug) | GITHUB_REPOSITORY_OWNER_PART | The owner name.                                                                                                      |
-| [GITHUB_REPOSITORY<br>_NAME_PART_SLUG](docs/slug-variables.md#github_repository_name_part_slug)   | GITHUB_REPOSITORY_NAME_PART  | The repository name.                                                                                                 |
-| [GITHUB_REF_SLUG](docs/slug-variables.md#github_ref_slug)                                         | GITHUB_REF                   | The branch or tag ref that triggered the workflow.                                                                   |
-| [GITHUB_HEAD_REF_SLUG](docs/slug-variables.md#github_head_ref_slug)                               | GITHUB_HEAD_REF              | The branch of the head repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
-| [GITHUB_BASE_REF_SLUG](docs/slug-variables.md#github_base_ref_slug)                               | GITHUB_BASE_REF              | The branch of the base repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
-| [GITHUB_EVENT_REF_SLUG](docs/slug-variables.md#github_event_ref_slug)                             | _github.event.ref_           | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul>          |
+| Variable | Slug version of | Description |
+| -------- | --------------- | ----------- |
+| [GITHUB_REPOSITORY_SLUG](docs/slug-variables.md#github_repository_slug) | GITHUB_REPOSITORY | The owner and repository name. |
+| [GITHUB_REPOSITORY<br>_OWNER_PART_SLUG](docs/slug-variables.md#github_repository_owner_part_slug) | GITHUB_REPOSITORY_OWNER_PART | The owner name. |
+| [GITHUB_REPOSITORY<br>_NAME_PART_SLUG](docs/slug-variables.md#github_repository_name_part_slug) | GITHUB_REPOSITORY_NAME_PART | The repository name. |
+| [GITHUB_REF_SLUG](docs/slug-variables.md#github_ref_slug) | GITHUB_REF | The branch or tag ref that triggered the workflow. |
+| [GITHUB_REF_NAME_SLUG](docs/slug-variables.md#github_ref_name_slug) | GITHUB_REF_NAME | This value matches the branch or tag name shown on GitHub. Similar to GITHUB_REF_SLUG. |
+| [GITHUB_HEAD_REF_SLUG](docs/slug-variables.md#github_head_ref_slug) | GITHUB_HEAD_REF | The branch of the head repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
+| [GITHUB_BASE_REF_SLUG](docs/slug-variables.md#github_base_ref_slug) | GITHUB_BASE_REF | The branch of the base repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
+| [GITHUB_EVENT_REF_SLUG](docs/slug-variables.md#github_event_ref_slug) | _github.event.ref_ | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul> |
 
 ### Slug URL variables
 
 > [!TIP]
 > `_CS` suffix also available
 
-| Variable                                                                                                  | Slug URL version of          | Description                                                                                                           |
-| --------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| [GITHUB_REPOSITORY_SLUG_URL](docs/slug-url-variables.md#github_repository_slug_url)                       | GITHUB_REPOSITORY            | The owner and repository name.                                                                                        |
-| [GITHUB_REPOSITORY<br>_OWNER_PART_SLUG_URL](docs/slug-variables.md#github_repository_owner_part_slug_url) | GITHUB_REPOSITORY_OWNER_PART | The owner name.                                                                                                       |
-| [GITHUB_REPOSITORY<br>_NAME_PART_SLUG_URL](docs/slug-variables.md#github_repository_name_part_slug_url)   | GITHUB_REPOSITORY_NAME_PART  | The repository name.                                                                                                  |
-| [GITHUB_REF_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url)                                     | GITHUB_REF                   | The branch or tag ref that triggered the workflow.                                                                    |
-| [GITHUB_HEAD_REF_SLUG_URL](docs/slug-url-variables.md#github_head_ref_slug_url)                           | GITHUB_HEAD_REF              | The branch of the head repository.<br>Only set for [pull-request][webhooks-and-events] event and forked repositories. |
-| [GITHUB_BASE_REF_SLUG_URL](docs/slug-url-variables.md#github_base_ref_slug_url)                           | GITHUB_BASE_REF              | The branch of the base repository.<br>Only set for [pull-request][webhooks-and-events] event and forked repositories. |
-| [GITHUB_EVENT_REF_SLUG_URL](docs/slug-url-variables.md#github_event_ref_slug_url)                         | _github.event.ref_           | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul>           |
+| Variable | Slug URL version of | Description |
+| -------- | ------------------- | ----------- |
+| [GITHUB_REPOSITORY_SLUG_URL](docs/slug-url-variables.md#github_repository_slug_url) | GITHUB_REPOSITORY | The owner and repository name. |
+| [GITHUB_REPOSITORY<br>_OWNER_PART_SLUG_URL](docs/slug-variables.md#github_repository_owner_part_slug_url) | GITHUB_REPOSITORY_OWNER_PART | The owner name. |
+| [GITHUB_REPOSITORY<br>_NAME_PART_SLUG_URL](docs/slug-variables.md#github_repository_name_part_slug_url) | GITHUB_REPOSITORY_NAME_PART | The repository name. |
+| [GITHUB_REF_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | GITHUB_REF | The branch or tag ref that triggered the workflow. |
+| [GITHUB_REF_NAME_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | GITHUB_REF_NAME | This value matches the branch or tag name shown on GitHub. Similar to GITHUB_REF_SLUG_URL. |
+| [GITHUB_HEAD_REF_SLUG_URL](docs/slug-url-variables.md#github_head_ref_slug_url) | GITHUB_HEAD_REF | The branch of the head repository.<br>Only set for [pull-request][webhooks-and-events] event and forked repositories. |
+| [GITHUB_BASE_REF_SLUG_URL](docs/slug-url-variables.md#github_base_ref_slug_url) | GITHUB_BASE_REF | The branch of the base repository.<br>Only set for [pull-request][webhooks-and-events] event and forked repositories. |
+| [GITHUB_EVENT_REF_SLUG_URL](docs/slug-url-variables.md#github_event_ref_slug_url) | _github.event.ref_ | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul> |
 
 ### Short variables
 
-| Variable                                                                                                             | Short version of                             | Description                                                                                                                                                                                                                                             |
-| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [GITHUB_SHA_SHORT](docs/short-variables.md#github_sha_short)                                                         | GITHUB_SHA                                   | The commit SHA that triggered the workflow.                                                                                                                                                                                                             |
+| Variable | Short version of | Description |
+| -------- | ---------------- | ----------- |
+| [GITHUB_SHA_SHORT](docs/short-variables.md#github_sha_short) | GITHUB_SHA | The commit SHA that triggered the workflow. |
 | [GITHUB_EVENT<br>_PULL_REQUEST<br>_HEAD_SHA_SHORT](docs/short-variables.md#github_event_pull_request_head_sha_short) | _github.event<br>.pull_request<br>.head.sha_ | The commit SHA on pull request that trigger workflow.<br>Only set for [following webhook events][webhooks-and-events]<ul><li>`pull_request`</li><li>`pull_request_review`</li><li>`pull_request_review_comment`</li><li>`pull_request_target`</li></ul> |
 
 ## Troubleshooting
@@ -184,7 +185,34 @@ To manage that moving length, you can use `short-length` input
 - set `7` to reproduce `small repository` behavior
 - set `8` to reproduce `v3` behavior
 
-**Warning**: The minimum length is 4, the default is the effective value of the [core.abbrev][git-core-abbrev] configuration variable.
+> [!WARNING]
+> The minimum length is 4, the default is the effective value of the [core.abbrev][git-core-abbrev] configuration variable.
+
+### The GITHUB_REF_NAME SLUG/SLUG_URL variables doesn't work the same way as before
+
+> [!TIP]
+> If you use `v5` or related versions, you need to use `GITHUB_REF_POINT` instead of `GITHUB_REF_NAME` to get the behavior of the `v4` action.
+
+Before `v5`, the behavior was the same as the GitHub one except on `pull_request*` workflows ([Ready the full story][issue-104]).
+
+- `${{ env.GITHUB_REF_NAME }}` will serve the behavior of this action,
+- `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
+
+On `pull_request*` workflows, the content will be `<PR-number>/merge` instead of the branch name.
+So you need to use `GITHUB_REF_POINT` instead
+
+```yaml
+steps:
+  - name: Inject enhanced GitHub environment variables
+    uses: rlespinasse/github-slug-action@v5
+  - run: |
+      echo "Branch Name: ${GITHUB_REF_POINT}"
+    shell: bash
+
+```
+
+Then `${{ env.GITHUB_REF_POINT }}`, and `$GITHUB_REF_POINT` will serve the behavior of this action.
+And `${{ env.GITHUB_REF_NAME }}`, and `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
 
 ### One of the environment variables doesn't work as intended
 
@@ -203,47 +231,6 @@ This will not occurs if you use the `prefix` input to avoid the issue.
 
 > [!IMPORTANT]
 > If detected, the maintainers of this action will choose the best course of action depending of the impact.
-
-#### Known environment variable conflicts
-
-##### GITHUB_REF_NAME
-
-If you use `v5` or related versions, you need to use `GITHUB_REF_POINT` instead of `GITHUB_REF_NAME`.
-
-Before `v5`, the behavior is the same as the GitHub one except on `pull_request*` workflows ([Ready the full story][issue-104]).
-
-- `${{ env.GITHUB_REF_NAME }}` will serve the behavior of this action,
-- `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
-
-On `pull_request*` workflows, the content will be `<PR-number>/merge` instead of the branch name.
-
-A possible workaround is to use `prefix` input
-
-```yaml
-steps:
-  - name: Inject enhanced GitHub environment variables
-    uses: rlespinasse/github-slug-action@v4
-    with:
-      prefix: CI_
-  - run: |
-      echo "Branch Name: ${CI_GITHUB_REF_NAME}"
-    shell: bash
-```
-
-or to use `v5` and move to `GITHUB_REF_POINT`
-
-```yaml
-steps:
-  - name: Inject enhanced GitHub environment variables
-    uses: rlespinasse/github-slug-action@v5
-  - run: |
-      echo "Branch Name: ${GITHUB_REF_POINT}"
-    shell: bash
-
-```
-
-Then `${{ env.CI_GITHUB_REF_NAME }}`, and `$CI_GITHUB_REF_NAME` will serve the behavior of this action.
-And `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
 
 ### An action could not be found at the URI
 

--- a/README.md
+++ b/README.md
@@ -2,26 +2,6 @@
 
 This GitHub Action will expose the slug/short values of [some GitHub environment variables][default-environment-variables] inside your GitHub workflow.
 
-## Table of Contents
-
-- [GitHub Slug action](#github-slug-action)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-  - [Use this action](#use-this-action)
-    - [Migration from previous versions](#migration-from-previous-versions)
-  - [Available Environment variables](#available-environment-variables)
-    - [Enhanced variables](#enhanced-variables)
-    - [Partial variables](#partial-variables)
-    - [Slug variables](#slug-variables)
-    - [Slug URL variables](#slug-url-variables)
-    - [Short variables](#short-variables)
-  - [Troubleshooting](#troubleshooting)
-    - [The SHORT variables doesn't have the same lengths as before](#the-short-variables-doesnt-have-the-same-lengths-as-before)
-    - [The GITHUB\_REF\_NAME SLUG/SLUG\_URL variables doesn't work the same way as before](#the-github_ref_name-slugslug_url-variables-doesnt-work-the-same-way-as-before)
-    - [One of the environment variables doesn't work as intended](#one-of-the-environment-variables-doesnt-work-as-intended)
-    - [An action could not be found at the URI](#an-action-could-not-be-found-at-the-uri)
-  - [Thanks for talking about us](#thanks-for-talking-about-us)
-
 ## Overview
 
 `SLUG` on a variable will
@@ -32,9 +12,7 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
 - limit the string size to 63 characters
 - remove trailing `-` characters
 
-<details>
-  <summary>Others <b>Slug-ish</b> commands are available</summary>
-  <p>
+### Others Slug-ish variables are available
 
 - `SLUG_URL` on a variable to have a `slug` variable compliant to be used in a URL
   - Like `SLUG` but `.`, and `_` are also replaced by `-`
@@ -45,78 +23,59 @@ This GitHub Action will expose the slug/short values of [some GitHub environment
 - `<VAR>_CS` on others variables to keep the value case-sensitive
   - Like `GITHUB_REF_SLUG_CS`
 
-Additional enhanced environment variables can be compute to help you around GitHub environment variables.
-  </p>
-</details>
-
 ## Use this action
 
-Add this in your workflow
+Add this in your workflow, or check for more [examples][examples] (OS usage, URL use, ...)
 
 ```yaml
-- name: Inject enhanced GitHub environment variables
-  uses: rlespinasse/github-slug-action@v5
+steps:
+  - name: Inject enhanced GitHub environment variables
+    uses: rlespinasse/github-slug-action@v5
 ```
 
-<details>
-  <summary>Others configurations</summary>
-  <p>
+> [!TIP]
+> Use [Dependabot][dependabot] to maintain your `github-slug-action` version updated in your GitHub workflows.
 
-- With a prefix
+### With a prefix
 
-  ```yaml
+```yaml
+steps:
   - name: Inject enhanced GitHub environment variables
     uses: rlespinasse/github-slug-action@v5
     with:
       prefix: CI_
-  ```
+```
 
-- With another max length for slug values
+### With another max length for slug values
 
-  ```yaml
+```yaml
+steps:
   - name: Inject enhanced GitHub environment variables
     uses: rlespinasse/github-slug-action@v5
     with:
       slug-maxlength: 80 # Use 'nolimit' to remove use of a max length (Default to 63)
-  ```
+```
 
-- With another length for short values
+### With another length for short values
 
-  ```yaml
+```yaml
+steps:
   - name: Inject enhanced GitHub environment variables
     uses: rlespinasse/github-slug-action@v5
     with:
       short-length: 7 # By default it's up to Git to decide, use 8 to have the v3.x behavior
-  ```
-
-  **Warning**: If you leave it empty, you need to checkout the source first in order to let Git decide the size by itself.
-  </p>
-</details>
-
-Check for more [examples][examples] (OS usage, URL use, ...)
-
-**Tip:** Use [Dependabot][dependabot] to maintain your `github-slug-action` version updated in your GitHub workflows.
-
-### Migration from previous versions
-
-The short sha length is not the same as previous version.
-
-- Since `v4` let Git configuration decide of it (but you can override it),
-- With `v3` and before, it's always a length of 8 characters.
-
-So to reproduce previous behavior, use
-
-```yaml
-- name: Inject enhanced GitHub environment variables
-  uses: rlespinasse/github-slug-action@v5
-  with:
-    short-length: 8 # Same as v3 and before
 ```
+
+> [!WARNING]
+> If you leave it empty, you need to checkout the source first in order to let Git decide the size by itself.
 
 ## Available Environment variables
 
-> [!NOTE]
-> If you don't find what you search for, read more about [available `GitHub` variables](docs/github-variables.md), and propose a [new custom variable][custom-variable].
+> [!TIP]
+> If you don't find what you search for
+>
+> - Read more about [available `GitHub` variables](docs/github-variables.md), and propose a [new custom variable][custom-variable].
+> - Use your own variable with [slugify-value][slugify-value], or [shortify-git-revision][shortify-git-revision] for git reference.
 
 ### Enhanced variables
 
@@ -137,58 +96,47 @@ So to reproduce previous behavior, use
 ### Slug variables
 
 > [!TIP]
-> `_CS` suffix also available
+> `_CS` suffix also available for Case-Sensitive preservation
 
-| Variable | Slug version of | Description |
-| -------- | --------------- | ----------- |
-| [GITHUB_REPOSITORY_SLUG](docs/slug-variables.md#github_repository_slug) | GITHUB_REPOSITORY | The owner and repository name. |
-| [GITHUB_REPOSITORY<br>_OWNER_PART_SLUG](docs/slug-variables.md#github_repository_owner_part_slug) | GITHUB_REPOSITORY_OWNER_PART | The owner name. |
-| [GITHUB_REPOSITORY<br>_NAME_PART_SLUG](docs/slug-variables.md#github_repository_name_part_slug) | GITHUB_REPOSITORY_NAME_PART | The repository name. |
-| [GITHUB_REF_SLUG](docs/slug-variables.md#github_ref_slug) | GITHUB_REF | The branch or tag ref that triggered the workflow. |
-| [GITHUB_REF_NAME_SLUG](docs/slug-variables.md#github_ref_name_slug) | GITHUB_REF_NAME | This value matches the branch or tag name shown on GitHub. Similar to GITHUB_REF_SLUG. |
-| [GITHUB_HEAD_REF_SLUG](docs/slug-variables.md#github_head_ref_slug) | GITHUB_HEAD_REF | The branch of the head repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
-| [GITHUB_BASE_REF_SLUG](docs/slug-variables.md#github_base_ref_slug) | GITHUB_BASE_REF | The branch of the base repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
-| [GITHUB_EVENT_REF_SLUG](docs/slug-variables.md#github_event_ref_slug) | _github.event.ref_ | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul> |
+| Variable | Description |
+| -------- | ----------- |
+| [GITHUB_REPOSITORY_SLUG](docs/slug-variables.md#github_repository_slug) | The owner and repository name. |
+| [GITHUB_REPOSITORY_OWNER_PART_SLUG](docs/slug-variables.md#github_repository_owner_part_slug) | The owner name. |
+| [GITHUB_REPOSITORY_NAME_PART_SLUG](docs/slug-variables.md#github_repository_name_part_slug) | The repository name. |
+| [GITHUB_REF_SLUG](docs/slug-variables.md#github_ref_slug) | The branch or tag ref that triggered the workflow. |
+| [GITHUB_REF_NAME_SLUG](docs/slug-variables.md#github_ref_name_slug) | This value matches the branch or tag name shown on GitHub. |
+| [GITHUB_HEAD_REF_SLUG](docs/slug-variables.md#github_head_ref_slug) | The branch of the head repository. |
+| [GITHUB_BASE_REF_SLUG](docs/slug-variables.md#github_base_ref_slug) | The branch of the base repository. |
+| [GITHUB_EVENT_REF_SLUG](docs/slug-variables.md#github_event_ref_slug) | The Git reference resource associated to triggered webhook. |
 
 ### Slug URL variables
 
 > [!TIP]
-> `_CS` suffix also available
+> `_CS` suffix also available for Case-Sensitive preservation
 
-| Variable | Slug URL version of | Description |
-| -------- | ------------------- | ----------- |
-| [GITHUB_REPOSITORY_SLUG_URL](docs/slug-url-variables.md#github_repository_slug_url) | GITHUB_REPOSITORY | The owner and repository name. |
-| [GITHUB_REPOSITORY<br>_OWNER_PART_SLUG_URL](docs/slug-variables.md#github_repository_owner_part_slug_url) | GITHUB_REPOSITORY_OWNER_PART | The owner name. |
-| [GITHUB_REPOSITORY<br>_NAME_PART_SLUG_URL](docs/slug-variables.md#github_repository_name_part_slug_url) | GITHUB_REPOSITORY_NAME_PART | The repository name. |
-| [GITHUB_REF_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | GITHUB_REF | The branch or tag ref that triggered the workflow. |
-| [GITHUB_REF_NAME_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | GITHUB_REF_NAME | This value matches the branch or tag name shown on GitHub. Similar to GITHUB_REF_SLUG_URL. |
-| [GITHUB_HEAD_REF_SLUG_URL](docs/slug-url-variables.md#github_head_ref_slug_url) | GITHUB_HEAD_REF | The branch of the head repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
-| [GITHUB_BASE_REF_SLUG_URL](docs/slug-url-variables.md#github_base_ref_slug_url) | GITHUB_BASE_REF | The branch of the base repository.<br>Only set for [pull-request][event-pull-request] event and forked repositories. |
-| [GITHUB_EVENT_REF_SLUG_URL](docs/slug-url-variables.md#github_event_ref_slug_url) | _github.event.ref_ | <br>Only set for [following webhook events][webhooks-and-events]<ul><li>`create`</li><li>`delete`</li></ul> |
+| Variable | Description |
+| -------- | ----------- |
+| [GITHUB_REPOSITORY_SLUG_URL](docs/slug-url-variables.md#github_repository_slug_url) | The owner and repository name. |
+| [GITHUB_REPOSITORY_OWNER_PART_SLUG_URL](docs/slug-variables.md#github_repository_owner_part_slug_url) | The owner name. |
+| [GITHUB_REPOSITORY_NAME_PART_SLUG_URL](docs/slug-variables.md#github_repository_name_part_slug_url) | The repository name. |
+| [GITHUB_REF_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | The branch or tag ref that triggered the workflow. |
+| [GITHUB_REF_NAME_SLUG_URL](docs/slug-url-variables.md#github_ref_slug_url) | This value matches the branch or tag name shown on GitHub. |
+| [GITHUB_HEAD_REF_SLUG_URL](docs/slug-url-variables.md#github_head_ref_slug_url) | The branch of the head repository. |
+| [GITHUB_BASE_REF_SLUG_URL](docs/slug-url-variables.md#github_base_ref_slug_url) | The branch of the base repository. |
+| [GITHUB_EVENT_REF_SLUG_URL](docs/slug-url-variables.md#github_event_ref_slug_url) | The Git reference resource associated to triggered webhook. |
 
 ### Short variables
 
-| Variable | Short version of | Description |
-| -------- | ---------------- | ----------- |
-| [GITHUB_SHA_SHORT](docs/short-variables.md#github_sha_short) | GITHUB_SHA | The commit SHA that triggered the workflow. |
-| [GITHUB_EVENT<br>_PULL_REQUEST<br>_HEAD_SHA_SHORT](docs/short-variables.md#github_event_pull_request_head_sha_short) | _github.event<br>.pull_request<br>.head.sha_ | The commit SHA on pull request that trigger workflow.<br>Only set for [following webhook events][webhooks-and-events]<ul><li>`pull_request`</li><li>`pull_request_review`</li><li>`pull_request_review_comment`</li><li>`pull_request_target`</li></ul> |
+| Variable | Description |
+| -------- | ----------- |
+| [GITHUB_SHA_SHORT](docs/short-variables.md#github_sha_short) | The commit SHA that triggered the workflow. |
+| [GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT](docs/short-variables.md#github_event_pull_request_head_sha_short) |  The commit SHA on pull request that trigger workflow. |
 
-## Troubleshooting
+## Migration from previous versions
 
-### The SHORT variables doesn't have the same lengths as before
+### From v4
 
-Since `v4`, it's Git who manage the short variables by using [`git rev-parse`][git-revparse] behaviour.
-The length of a short sha depends of the size of our repository and can differ over time.
-
-To manage that moving length, you can use `short-length` input
-
-- set `7` to reproduce `small repository` behavior
-- set `8` to reproduce `v3` behavior
-
-> [!WARNING]
-> The minimum length is 4, the default is the effective value of the [core.abbrev][git-core-abbrev] configuration variable.
-
-### The GITHUB_REF_NAME SLUG/SLUG_URL variables doesn't work the same way as before
+The **GITHUB_REF_NAME SLUG/SLUG_URL** variables doesn't work the same way as before
 
 > [!TIP]
 > If you use `v5` or related versions, you need to use `GITHUB_REF_POINT` instead of `GITHUB_REF_NAME` to get the behavior of the `v4` action.
@@ -213,6 +161,31 @@ steps:
 
 Then `${{ env.GITHUB_REF_POINT }}`, and `$GITHUB_REF_POINT` will serve the behavior of this action.
 And `${{ env.GITHUB_REF_NAME }}`, and `$GITHUB_REF_NAME` will serve the behavior of GitHub Action.
+
+### From v3
+
+Since `v4`, it's Git who manage the short variables by using [`git rev-parse`][git-revparse] behaviour.
+The length of a short sha depends of the size of our repository and can differ over time.
+
+To manage that moving length, you can use `short-length` input
+
+- set `7` to reproduce `small repository` behavior
+- set `8` to reproduce `v3` behavior
+
+> [!WARNING]
+> The minimum length is 4, the default is the effective value of the [core.abbrev][git-core-abbrev] configuration variable.
+
+So to reproduce previous behavior, use
+
+```yaml
+steps:
+  - name: Inject enhanced GitHub environment variables
+    uses: rlespinasse/github-slug-action@v5
+    with:
+      short-length: 8 # Same as v3 and before
+```
+
+## Troubleshooting
 
 ### One of the environment variables doesn't work as intended
 
@@ -273,13 +246,15 @@ In Chinese :cn:
 [issue-15]: https://github.com/rlespinasse/github-slug-action/issues/15
 [issue-104]: https://github.com/rlespinasse/github-slug-action/issues/104
 
+[slugify-value]: https://github.com/rlespinasse/slugify-value
+[shortify-git-revision]: https://github.com/rlespinasse/shortify-git-revision
+
 [git-revparse]: https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength
 [git-core-abbrev]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev
 
 [default-environment-variables]: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 [dependabot]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
 [webhooks-and-events]: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads
-[event-pull-request]: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request
 [naming-conventions]: https://docs.github.com/en/actions/reference/environment-variables#naming-conventions-for-environment-variables
 
 [article-1]: https://esensconsulting.medium.com/mettre-en-place-une-ci-cd-angular-avec-github-actions-netlify-ca0b59b99ed8

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,12 @@ runs:
         slug-maxlength: ${{ inputs.slug-maxlength }}
     - uses: rlespinasse/slugify-value@v1.4.0
       with:
+        key: GITHUB_REF_NAME
+        value: ${{ github.ref_name }}
+        prefix: ${{ inputs.prefix }}
+        slug-maxlength: ${{ inputs.slug-maxlength }}
+    - uses: rlespinasse/slugify-value@v1.4.0
+      with:
         key: GITHUB_REF_POINT
         value: ${{ env.GITHUB_HEAD_REF_RAW || env.GITHUB_REF_NAME_RAW }}
         prefix: ${{ inputs.prefix }}

--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,7 @@ runs:
         slug-maxlength: ${{ inputs.slug-maxlength }}
     - uses: rlespinasse/slugify-value@v1.4.0
       with:
-        key: GITHUB_REF_NAME
-        # Related to https://github.com/rlespinasse/github-slug-action/issues/104
+        key: GITHUB_REF_POINT
         value: ${{ env.GITHUB_HEAD_REF_RAW || env.GITHUB_REF_NAME_RAW }}
         prefix: ${{ inputs.prefix }}
         slug-maxlength: ${{ inputs.slug-maxlength }}

--- a/docs/github-variables.md
+++ b/docs/github-variables.md
@@ -12,10 +12,10 @@ All `GitHub` variables availables in your workflow in addition of ones exposed b
     - [Action-managed Event Variables](#action-managed-event-variables)
       - [create](#create)
       - [delete](#delete)
-      - [pull_request](#pull_request)
-      - [pull_request_review](#pull_request_review)
-      - [pull_request_review_comment](#pull_request_review_comment)
-      - [pull_request_target](#pull_request_target)
+      - [pull\_request](#pull_request)
+      - [pull\_request\_review](#pull_request_review)
+      - [pull\_request\_review\_comment](#pull_request_review_comment)
+      - [pull\_request\_target](#pull_request_target)
 
 ## Default environment variables
 
@@ -23,13 +23,14 @@ Read the official documentation about [Default environment variables][1].
 
 ### Action-managed Environment Variables
 
-| Action-managed Variables | Can be suffix by     |
-| ------------------------ | -------------------- |
-| GITHUB_REPOSITORY        | `_SLUG`, `_SLUG_URL` |
-| GITHUB_REF               | `_SLUG`, `_SLUG_URL` |
-| GITHUB_HEAD_REF          | `_SLUG`, `_SLUG_URL` |
-| GITHUB_BASE_REF          | `_SLUG`, `_SLUG_URL` |
-| GITHUB_SHA               | `_SHORT`             |
+| Action-managed Variables | Can be suffix by |
+| ------------------------ | --------------- |
+| GITHUB_REPOSITORY | `_SLUG`, `_SLUG_URL` |
+| GITHUB_REF | `_SLUG`, `_SLUG_URL` |
+| GITHUB_REF_NAME | `_SLUG`, `_SLUG_URL` |
+| GITHUB_HEAD_REF | `_SLUG`, `_SLUG_URL` |
+| GITHUB_BASE_REF | `_SLUG`, `_SLUG_URL` |
+| GITHUB_SHA | `_SHORT` |
 
 ## Variables from events
 
@@ -41,50 +42,50 @@ Read the official documentation about [Events that trigger workflows][2].
 
 Checkout [create][3] webhook payload content
 
-| Action-managed Variables | Available as              |
-| ------------------------ | ------------------------- |
-| github.event.ref         | GITHUB_EVENT_REF_SLUG     |
-| github.event.ref         | GITHUB_EVENT_REF_SLUG_URL |
+| Action-managed Variables | Available as |
+| ------------------------ | ------------ |
+| github.event.ref | GITHUB_EVENT_REF_SLUG |
+| github.event.ref | GITHUB_EVENT_REF_SLUG_URL |
 
 #### delete
 
 Checkout [delete][4] webhook payload content
 
-| Action-managed Variables | Available as              |
-| ------------------------ | ------------------------- |
-| github.event.ref         | GITHUB_EVENT_REF_SLUG     |
-| github.event.ref         | GITHUB_EVENT_REF_SLUG_URL |
+| Action-managed Variables | Available as |
+| ------------------------ | ------------ |
+| github.event.ref | GITHUB_EVENT_REF_SLUG |
+| github.event.ref | GITHUB_EVENT_REF_SLUG_URL |
 
 #### pull_request
 
 Checkout [pull_request][5] webhook payload content
 
-| Action-managed Variables           | Available as                             |
-| ---------------------------------- | ---------------------------------------- |
+| Action-managed Variables | Available as |
+| ------------------------ | ------------ |
 | github.event.pull_request.head.sha | GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT |
 
 #### pull_request_review
 
 Checkout [pull_request_review][6] webhook payload content
 
-| Action-managed Variables           | Available as                             |
-| ---------------------------------- | ---------------------------------------- |
+| Action-managed Variables | Available as |
+| ------------------------ | ------------ |
 | github.event.pull_request.head.sha | GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT |
 
 #### pull_request_review_comment
 
 Checkout [pull_request_review_comment][7] webhook payload content
 
-| Action-managed Variables           | Available as                             |
-| ---------------------------------- | ---------------------------------------- |
+| Action-managed Variables | Available as |
+| ------------------------ | ------------ |
 | github.event.pull_request.head.sha | GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT |
 
 #### pull_request_target
 
 Checkout [pull_request][5] webhook payload content
 
-| Action-managed Variables           | Available as                             |
-| ---------------------------------- | ---------------------------------------- |
+| Action-managed Variables | Available as |
+| ------------------------ | ------------ |
 | github.event.pull_request.head.sha | GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT |
 
 [1]: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables

--- a/docs/partial-variables.md
+++ b/docs/partial-variables.md
@@ -4,25 +4,25 @@
 
 - [Partial Variables](#partial-variables)
   - [Table of Contents](#table-of-contents)
-  - [GITHUB_REPOSITORY_OWNER_PART](#github_repository_owner_part)
-  - [GITHUB_REPOSITORY_NAME_PART](#github_repository_name_part)
+  - [GITHUB\_REPOSITORY\_OWNER\_PART](#github_repository_owner_part)
+  - [GITHUB\_REPOSITORY\_NAME\_PART](#github_repository_name_part)
 
 ## GITHUB_REPOSITORY_OWNER_PART
 
 Owner part of the environment variable **GITHUB_REPOSITORY**
 
-| GITHUB_REPOSITORY            | GITHUB_REPOSITORY_OWNER_PART |
-| ---------------------------- | ---------------------------- |
-| octocat/Hello-World          | octocat                      |
-| rlespinasse/Hello-World.go   | rlespinasse                  |
-| AnotherPerson/SomeRepository | AnotherPerson                |
+| GITHUB_REPOSITORY | GITHUB_REPOSITORY_OWNER_PART |
+| ----------------- | ---------------------------- |
+| octocat/Hello-World | octocat |
+| rlespinasse/Hello-World.go | rlespinasse |
+| AnotherPerson/SomeRepository | AnotherPerson |
 
 ## GITHUB_REPOSITORY_NAME_PART
 
 Repository name part of the environment variable **GITHUB_REPOSITORY**
 
-| GITHUB_REPOSITORY            | GITHUB_REPOSITORY_NAME_PART |
-| ---------------------------- | --------------------------- |
-| octocat/Hello-World          | Hello-World                 |
-| rlespinasse/Hello-World.go   | Hello-World.go              |
-| AnotherPerson/SomeRepository | SomeRepository              |
+| GITHUB_REPOSITORY | GITHUB_REPOSITORY_NAME_PART |
+| ----------------- | --------------------------- |
+| octocat/Hello-World | Hello-World |
+| rlespinasse/Hello-World.go | Hello-World.go |
+| AnotherPerson/SomeRepository | SomeRepository |

--- a/docs/short-variables.md
+++ b/docs/short-variables.md
@@ -4,8 +4,8 @@
 
 - [Short Variables](#short-variables)
   - [Table of Contents](#table-of-contents)
-  - [GITHUB_SHA_SHORT](#github_sha_short)
-  - [GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT](#github_event_pull_request_head_sha_short)
+  - [GITHUB\_SHA\_SHORT](#github_sha_short)
+  - [GITHUB\_EVENT\_PULL\_REQUEST\_HEAD\_SHA\_SHORT](#github_event_pull_request_head_sha_short)
 
 ## GITHUB_SHA_SHORT
 
@@ -13,15 +13,15 @@ Short the environment variable **GITHUB_SHA**
 
 The commit SHA that triggered the workflow
 
-| GITHUB_SHA                               | GITHUB_SHA_SHORT |
-| ---------------------------------------- | ---------------- |
-| ffac537e6cbbf934b08745a378932722df287a53 | ffac537e         |
+| GITHUB_SHA | GITHUB_SHA_SHORT |
+| ---------- | ---------------- |
+| ffac537e6cbbf934b08745a378932722df287a53 | ffac537e |
 
 ## GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT
 
 Short the value of `github.event.pull_request.head.sha` that represents the last commit
 used for triggering an action for a pull request.
 
-| github.event.pull_request.head.sha       | GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT |
-| ---------------------------------------- | ---------------------------------------- |
-| ffac537e6cbbf934b08745a378932722df287a53 | ffac537e                                 |
+| github.event.pull_request.head.sha | GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT |
+| ---------------------------------- | ---------------------------------------- |
+| ffac537e6cbbf934b08745a378932722df287a53 | ffac537e |

--- a/docs/slug-url-variables.md
+++ b/docs/slug-url-variables.md
@@ -111,7 +111,7 @@ _Only set for forked repositories._
 
 Slug URL the variable **github.event.ref**
 
-The git reference resource associated to triggered webhook.
+The Git reference resource associated to triggered webhook.
 _Only set for [`create`, and `delete`][1] events._
 
 | GITHUB_REF | GITHUB_HEAD_REF_SLUG_URL |

--- a/docs/slug-url-variables.md
+++ b/docs/slug-url-variables.md
@@ -4,13 +4,14 @@
 
 - [Slug URL Variables](#slug-url-variables)
   - [Table of Contents](#table-of-contents)
-  - [GITHUB_REPOSITORY_SLUG_URL](#github_repository_slug_url)
-  - [GITHUB_REPOSITORY_OWNER_PART_SLUG_URL](#github_repository_owner_part_slug_url)
-  - [GITHUB_REPOSITORY_NAME_PART_SLUG_URL](#github_repository_name_part_slug_url)
-  - [GITHUB_REF_SLUG_URL](#github_ref_slug_url)
-  - [GITHUB_HEAD_REF_SLUG_URL](#github_head_ref_slug_url)
-  - [GITHUB_BASE_REF_SLUG_URL](#github_base_ref_slug_url)
-  - [GITHUB_EVENT_REF_SLUG_URL](#github_event_ref_slug_url)
+  - [GITHUB\_REPOSITORY\_SLUG\_URL](#github_repository_slug_url)
+  - [GITHUB\_REPOSITORY\_OWNER\_PART\_SLUG\_URL](#github_repository_owner_part_slug_url)
+  - [GITHUB\_REPOSITORY\_NAME\_PART\_SLUG\_URL](#github_repository_name_part_slug_url)
+  - [GITHUB\_REF\_SLUG\_URL](#github_ref_slug_url)
+  - [GITHUB\_REF\_NAME\_SLUG\_URL](#github_ref_name_slug_url)
+  - [GITHUB\_HEAD\_REF\_SLUG\_URL](#github_head_ref_slug_url)
+  - [GITHUB\_BASE\_REF\_SLUG\_URL](#github_base_ref_slug_url)
+  - [GITHUB\_EVENT\_REF\_SLUG\_URL](#github_event_ref_slug_url)
 
 ## GITHUB_REPOSITORY_SLUG_URL
 
@@ -18,10 +19,10 @@ Slug URL the environment variable **GITHUB_REPOSITORY**
 
 The owner and repository name.
 
-| GITHUB_REPOSITORY            | GITHUB_REPOSITORY_SLUG_URL   |
-| ---------------------------- | ---------------------------- |
-| octocat/Hello-World          | octocat-hello-world          |
-| rlespinasse/Hello-World.go   | rlespinasse-hello-world-go   |
+| GITHUB_REPOSITORY | GITHUB_REPOSITORY_SLUG_URL |
+| ----------------- | ---------------------------- |
+| octocat/Hello-World | octocat-hello-world |
+| rlespinasse/Hello-World.go | rlespinasse-hello-world-go |
 | AnotherPerson/SomeRepository | anotherperson-somerepository |
 
 ## GITHUB_REPOSITORY_OWNER_PART_SLUG_URL
@@ -32,9 +33,9 @@ The Owner part of **GITHUB_REPOSITORY** variable.
 
 | GITHUB_REPOSITORY_OWNER_PART | GITHUB_REPOSITORY_OWNER_PART_SLUG_URL |
 | ---------------------------- | ------------------------------------- |
-| octocat                      | octocat                               |
-| rlespinasse                  | rlespinasse                           |
-| AnotherPerson                | anotherperson                         |
+| octocat | octocat |
+| rlespinasse | rlespinasse |
+| AnotherPerson | anotherperson |
 
 ## GITHUB_REPOSITORY_NAME_PART_SLUG_URL
 
@@ -44,9 +45,9 @@ The Repository name part of **GITHUB_REPOSITORY** variable.
 
 | GITHUB_REPOSITORY_NAME_PART | GITHUB_REPOSITORY_NAME_PART_SLUG_URL |
 | --------------------------- | ------------------------------------ |
-| Hello-World                 | hello-world                          |
-| Hello-World.go              | hello-world-go                       |
-| SomeRepository              | somerepository                       |
+| Hello-World | hello-world |
+| Hello-World.go | hello-world-go |
+| SomeRepository | somerepository |
 
 ## GITHUB_REF_SLUG_URL
 
@@ -55,17 +56,30 @@ Slug URL the environment variable **GITHUB_REF**
 The branch or tag ref that triggered the workflow.
 _If neither a branch or tag is available for the event type, the variable will not exist._
 
-| GITHUB_REF                     | GITHUB_REF_SLUG_URL |
-| ------------------------------ | ------------------- |
-| refs/heads/main                | main                |
-| refs/heads/feat/new_feature    | feat-new-feature    |
-| refs/tags/v1.0.0               | v1-0-0              |
-| refs/pull/42-merge             | 42-merge            |
-| refs/tags/product@1.0.0-rc.2   | product-1-0-0-rc-2  |
+| GITHUB_REF | GITHUB_REF_SLUG_URL |
+| ---------- | ------------------- |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/tags/v1.0.0 | v1-0-0 |
+| refs/pull/42/merge | 42-merge |
+| refs/tags/product@1.0.0-rc.2 | product-1-0-0-rc-2 |
 | refs/heads/New_Awesome_Product | new-awesome-product |
 
-**Caution**: From v3.0.0 to v3.2.0 included, `GITHUB_REF_SLUG` have the wrong value on `pull_request` event.
-`refs/pull/42-merge` become `refs-pull-42-merge` instead of `42-merge`. The bug have been fixed in v3.3.0
+## GITHUB_REF_NAME_SLUG_URL
+
+Slug URL the environment variable **GITHUB_REF_NAME**
+
+The branch or tag ref that triggered the workflow.
+_If neither a branch or tag is available for the event type, the variable will not exist._
+
+| GITHUB_REF | GITHUB_REF_SLUG_URL |
+| ---------- | ------------------- |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/tags/v1.0.0 | v1-0-0 |
+| refs/pull/42/merge | 42-merge |
+| refs/tags/product@1.0.0-rc.2 | product-1-0-0-rc-2 |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 ## GITHUB_HEAD_REF_SLUG_URL
 
@@ -74,11 +88,11 @@ Slug URL the environment variable **GITHUB_HEAD_REF**
 The branch of the head repository.
 _Only set for forked repositories._
 
-| GITHUB_REF                     | GITHUB_HEAD_REF_SLUG_URL |
-| ------------------------------ | ------------------------ |
-| refs/heads/main                | main                     |
-| refs/heads/feat/new_feature    | feat-new-feature         |
-| refs/heads/New_Awesome_Product | new-awesome-product      |
+| GITHUB_REF | GITHUB_HEAD_REF_SLUG_URL |
+| ---------- | ------------------------ |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 ## GITHUB_BASE_REF_SLUG_URL
 
@@ -87,11 +101,11 @@ Slug URL the environment variable **GITHUB_BASE_REF**
 The branch of the base repository.
 _Only set for forked repositories._
 
-| GITHUB_REF                     | GITHUB_HEAD_REF_SLUG_URL |
-| ------------------------------ | ------------------------ |
-| refs/heads/main                | main                     |
-| refs/heads/feat/new_feature    | feat-new-feature         |
-| refs/heads/New_Awesome_Product | new-awesome-product      |
+| GITHUB_REF | GITHUB_HEAD_REF_SLUG_URL |
+| ---------- | ------------------------ |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 ## GITHUB_EVENT_REF_SLUG_URL
 
@@ -100,10 +114,10 @@ Slug URL the variable **github.event.ref**
 The git reference resource associated to triggered webhook.
 _Only set for [`create`, and `delete`][1] events._
 
-| GITHUB_REF                     | GITHUB_HEAD_REF_SLUG_URL |
-| ------------------------------ | ------------------------ |
-| refs/heads/main                | main                     |
-| refs/heads/feat/new_feature    | feat-new-feature         |
-| refs/heads/New_Awesome_Product | new-awesome-product      |
+| GITHUB_REF | GITHUB_HEAD_REF_SLUG_URL |
+| ---------- | ------------------------ |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 [1]: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads

--- a/docs/slug-url-variables.md
+++ b/docs/slug-url-variables.md
@@ -72,8 +72,8 @@ Slug URL the environment variable **GITHUB_REF_NAME**
 The branch or tag ref that triggered the workflow.
 _If neither a branch or tag is available for the event type, the variable will not exist._
 
-| GITHUB_REF | GITHUB_REF_SLUG_URL |
-| ---------- | ------------------- |
+| GITHUB_REF_NAME | GITHUB_REF_SLUG_URL |
+| --------------- | ------------------- |
 | refs/heads/main | main |
 | refs/heads/feat/new_feature | feat-new-feature |
 | refs/tags/v1.0.0 | v1-0-0 |

--- a/docs/slug-variables.md
+++ b/docs/slug-variables.md
@@ -20,7 +20,7 @@ Slug the environment variable **GITHUB_REPOSITORY**
 The owner and repository name.
 
 | GITHUB_REPOSITORY | GITHUB_REPOSITORY_SLUG |
-| ----------------- | ---------------------------- |
+| ----------------- | ---------------------- |
 | octocat/Hello-World | octocat-hello-world |
 | rlespinasse/Hello-World.go | rlespinasse-hello-world.go |
 | AnotherPerson/SomeRepository | anotherperson-somerepository |
@@ -57,7 +57,7 @@ The branch or tag ref that triggered the workflow.
 _If neither a branch or tag is available for the event type, the variable will not exist._
 
 | GITHUB_REF | GITHUB_REF_SLUG |
-| ------------------------------ | ------------------- |
+| ---------- | --------------- |
 | refs/heads/main | main |
 | refs/heads/feat/new_feature | feat-new-feature |
 | refs/tags/v1.0.0 | v1.0.0 |
@@ -71,14 +71,14 @@ Slug the environment variable **GITHUB_REF_NAME**
 The branch or tag ref that triggered the workflow.
 _If neither a branch or tag is available for the event type, the variable will not exist._
 
-| GITHUB_REF | GITHUB_REF_SLUG |
-| ------------------------------ | ------------------- |
-| refs/heads/main | main |
-| refs/heads/feat/new_feature | feat-new-feature |
-| refs/tags/v1.0.0 | v1.0.0 |
-| refs/tags/product@1.0.0-rc.2 | product-1.0.0-rc.2 |
-| refs/heads/New_Awesome_Product | new-awesome-product |
-| refs/pull/42/merge | 42-merge |
+| GITHUB_REF_NAME | GITHUB_REF_SLUG |
+| --------------- | --------------- |
+| main | main |
+| feat/new_feature | feat-new-feature |
+| v1.0.0 | v1.0.0 |
+| product@1.0.0-rc.2 | product-1.0.0-rc.2 |
+| New_Awesome_Product | new-awesome-product |
+| 42/merge | 42-merge |
 
 ## GITHUB_HEAD_REF_SLUG
 
@@ -88,7 +88,7 @@ The branch of the head repository.
 _Only set for [`pull-request`][1] event and forked repositories._
 
 | GITHUB_REF | GITHUB_HEAD_REF_SLUG |
-| ------------------------------ | -------------------- |
+| ---------- | -------------------- |
 | refs/heads/main | main |
 | refs/heads/feat/new_feature | feat-new-feature |
 | refs/heads/New_Awesome_Product | new-awesome-product |
@@ -101,7 +101,7 @@ The branch of the base repository.
 _Only set for [`pull-request`][1] event and forked repositories._
 
 | GITHUB_REF | GITHUB_HEAD_REF_SLUG |
-| ------------------------------ | -------------------- |
+| ---------- | -------------------- |
 | refs/heads/main | main |
 | refs/heads/feat/new_feature | feat-new-feature |
 | refs/heads/New_Awesome_Product | new-awesome-product |
@@ -114,7 +114,7 @@ The git reference resource associated to triggered webhook.
 _Only set for [`create`, and `delete`][1] events._
 
 | GITHUB_REF | GITHUB_HEAD_REF_SLUG |
-| ------------------------------ | -------------------- |
+| ---------- | -------------------- |
 | refs/heads/main | main |
 | refs/heads/feat/new_feature | feat-new-feature |
 | refs/heads/New_Awesome_Product | new-awesome-product |

--- a/docs/slug-variables.md
+++ b/docs/slug-variables.md
@@ -110,7 +110,7 @@ _Only set for [`pull-request`][1] event and forked repositories._
 
 Slug the variable **github.event.ref**
 
-The git reference resource associated to triggered webhook.
+The Git reference resource associated to triggered webhook.
 _Only set for [`create`, and `delete`][1] events._
 
 | GITHUB_REF | GITHUB_HEAD_REF_SLUG |

--- a/docs/slug-variables.md
+++ b/docs/slug-variables.md
@@ -4,13 +4,14 @@
 
 - [Slug Variables](#slug-variables)
   - [Table of Contents](#table-of-contents)
-  - [GITHUB_REPOSITORY_SLUG](#github_repository_slug)
-  - [GITHUB_REPOSITORY_OWNER_PART_SLUG](#github_repository_owner_part_slug)
-  - [GITHUB_REPOSITORY_NAME_PART_SLUG](#github_repository_name_part_slug)
-  - [GITHUB_REF_SLUG](#github_ref_slug)
-  - [GITHUB_HEAD_REF_SLUG](#github_head_ref_slug)
-  - [GITHUB_BASE_REF_SLUG](#github_base_ref_slug)
-  - [GITHUB_EVENT_REF_SLUG](#github_event_ref_slug)
+  - [GITHUB\_REPOSITORY\_SLUG](#github_repository_slug)
+  - [GITHUB\_REPOSITORY\_OWNER\_PART\_SLUG](#github_repository_owner_part_slug)
+  - [GITHUB\_REPOSITORY\_NAME\_PART\_SLUG](#github_repository_name_part_slug)
+  - [GITHUB\_REF\_SLUG](#github_ref_slug)
+  - [GITHUB\_REF\_NAME\_SLUG](#github_ref_name_slug)
+  - [GITHUB\_HEAD\_REF\_SLUG](#github_head_ref_slug)
+  - [GITHUB\_BASE\_REF\_SLUG](#github_base_ref_slug)
+  - [GITHUB\_EVENT\_REF\_SLUG](#github_event_ref_slug)
 
 ## GITHUB_REPOSITORY_SLUG
 
@@ -18,10 +19,10 @@ Slug the environment variable **GITHUB_REPOSITORY**
 
 The owner and repository name.
 
-| GITHUB_REPOSITORY            | GITHUB_REPOSITORY_SLUG       |
-| ---------------------------- | ---------------------------- |
-| octocat/Hello-World          | octocat-hello-world          |
-| rlespinasse/Hello-World.go   | rlespinasse-hello-world.go   |
+| GITHUB_REPOSITORY | GITHUB_REPOSITORY_SLUG |
+| ----------------- | ---------------------------- |
+| octocat/Hello-World | octocat-hello-world |
+| rlespinasse/Hello-World.go | rlespinasse-hello-world.go |
 | AnotherPerson/SomeRepository | anotherperson-somerepository |
 
 ## GITHUB_REPOSITORY_OWNER_PART_SLUG
@@ -32,9 +33,9 @@ The Owner part of **GITHUB_REPOSITORY** variable.
 
 | GITHUB_REPOSITORY_OWNER_PART | GITHUB_REPOSITORY_OWNER_PART_SLUG |
 | ---------------------------- | --------------------------------- |
-| octocat                      | octocat                           |
-| rlespinasse                  | rlespinasse                       |
-| AnotherPerson                | anotherperson                     |
+| octocat | octocat |
+| rlespinasse | rlespinasse |
+| AnotherPerson | anotherperson |
 
 ## GITHUB_REPOSITORY_NAME_PART_SLUG
 
@@ -44,9 +45,9 @@ The Repository name part of **GITHUB_REPOSITORY** variable.
 
 | GITHUB_REPOSITORY_NAME_PART | GITHUB_REPOSITORY_NAME_PART_SLUG |
 | --------------------------- | -------------------------------- |
-| Hello-World                 | hello-world                      |
-| Hello-World.go              | hello-world.go                   |
-| SomeRepository              | somerepository                   |
+| Hello-World | hello-world |
+| Hello-World.go | hello-world.go |
+| SomeRepository | somerepository |
 
 ## GITHUB_REF_SLUG
 
@@ -55,13 +56,29 @@ Slug the environment variable **GITHUB_REF**
 The branch or tag ref that triggered the workflow.
 _If neither a branch or tag is available for the event type, the variable will not exist._
 
-| GITHUB_REF                     | GITHUB_REF_SLUG     |
+| GITHUB_REF | GITHUB_REF_SLUG |
 | ------------------------------ | ------------------- |
-| refs/heads/main                | main                |
-| refs/heads/feat/new_feature    | feat-new-feature    |
-| refs/tags/v1.0.0               | v1.0.0              |
-| refs/tags/product@1.0.0-rc.2   | product-1.0.0-rc.2  |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/tags/v1.0.0 | v1.0.0 |
+| refs/tags/product@1.0.0-rc.2 | product-1.0.0-rc.2 |
 | refs/heads/New_Awesome_Product | new-awesome-product |
+
+## GITHUB_REF_NAME_SLUG
+
+Slug the environment variable **GITHUB_REF_NAME**
+
+The branch or tag ref that triggered the workflow.
+_If neither a branch or tag is available for the event type, the variable will not exist._
+
+| GITHUB_REF | GITHUB_REF_SLUG |
+| ------------------------------ | ------------------- |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/tags/v1.0.0 | v1.0.0 |
+| refs/tags/product@1.0.0-rc.2 | product-1.0.0-rc.2 |
+| refs/heads/New_Awesome_Product | new-awesome-product |
+| refs/pull/42/merge | 42-merge |
 
 ## GITHUB_HEAD_REF_SLUG
 
@@ -70,11 +87,11 @@ Slug the environment variable **GITHUB_HEAD_REF**
 The branch of the head repository.
 _Only set for [`pull-request`][1] event and forked repositories._
 
-| GITHUB_REF                     | GITHUB_HEAD_REF_SLUG |
+| GITHUB_REF | GITHUB_HEAD_REF_SLUG |
 | ------------------------------ | -------------------- |
-| refs/heads/main                | main                 |
-| refs/heads/feat/new_feature    | feat-new-feature     |
-| refs/heads/New_Awesome_Product | new-awesome-product  |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 ## GITHUB_BASE_REF_SLUG
 
@@ -83,11 +100,11 @@ Slug the environment variable **GITHUB_BASE_REF**
 The branch of the base repository.
 _Only set for [`pull-request`][1] event and forked repositories._
 
-| GITHUB_REF                     | GITHUB_HEAD_REF_SLUG |
+| GITHUB_REF | GITHUB_HEAD_REF_SLUG |
 | ------------------------------ | -------------------- |
-| refs/heads/main                | main                 |
-| refs/heads/feat/new_feature    | feat-new-feature     |
-| refs/heads/New_Awesome_Product | new-awesome-product  |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 ## GITHUB_EVENT_REF_SLUG
 
@@ -96,10 +113,10 @@ Slug the variable **github.event.ref**
 The git reference resource associated to triggered webhook.
 _Only set for [`create`, and `delete`][1] events._
 
-| GITHUB_REF                     | GITHUB_HEAD_REF_SLUG |
+| GITHUB_REF | GITHUB_HEAD_REF_SLUG |
 | ------------------------------ | -------------------- |
-| refs/heads/main                | main                 |
-| refs/heads/feat/new_feature    | feat-new-feature     |
-| refs/heads/New_Awesome_Product | new-awesome-product  |
+| refs/heads/main | main |
+| refs/heads/feat/new_feature | feat-new-feature |
+| refs/heads/New_Awesome_Product | new-awesome-product |
 
 [1]: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads


### PR DESCRIPTION
Resolves #147 

BREAKING CHANGE: Change the behavior of GITHUB_REF_NAME to match the default GitHub Action behavior,
BREAKING CHANGE: Introduce GITHUB_REF_POINT as a replacement for GITHUB_REF_NAME to match this GitHub Action behavior in v4.