### PR TITLE
Print a warning if a GITHUB_* variable from this action already exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ runs:
       env:
         INPUT_SLUG_MAXLENGTH: ${{ inputs.slug-maxlength }}
         INPUT_SHORT_LENGTH: ${{ inputs.short-length }}
+      outputs:
+        warnings: ${{ steps.prefligth.outputs.warnings }}
 
     # From Environment Variables
     - uses: rlespinasse/slugify-value@v1.4.0
@@ -118,3 +120,7 @@ runs:
         short-on-error: true
         length: ${{ steps.prefligth.outputs.PREFLIGHT_SHORT_LENGTH }}
         prefix: ${{ inputs.prefix }}
+
+    # Print warnings captured from preflight.sh
+    - name: Print warnings
+      run: echo "${{ steps.prefligth.outputs.warnings }}"

--- a/preflight.sh
+++ b/preflight.sh
@@ -36,3 +36,12 @@ if [ -f "$GITHUB_OUTPUT" ]; then
 else
   echo "::set-output name=PREFLIGHT_SHORT_LENGTH::${PREFLIGHT_SHORT_LENGTH}"
 fi
+
+# Check for existing GITHUB_* variables using the env command
+existing_github_vars=$(env | grep '^GITHUB_')
+
+# Print a warning if any existing GITHUB_* variables are found
+if [ -n "$existing_github_vars" ]; then
+  echo "::warning ::The following GITHUB_* variables already exist and may be overwritten:"
+  echo "$existing_github_vars"
+fi


### PR DESCRIPTION
Related to #77

Add a warning for existing GITHUB_* variables in the preflight.sh script.

* Check for existing GITHUB_* variables using the env command.
* Print a warning if any existing GITHUB_* variables are found.
* Update action.yml to capture and print warnings from preflight.sh.