### PR TITLE
ci: replace release-that action with semantic-release

### DIFF
--- a/.github/workflows/v5-release.yml
+++ b/.github/workflows/v5-release.yml
@@ -21,6 +21,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 21
-          branches: main
+          branches: v5.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/v5-release.yml
+++ b/.github/workflows/v5-release.yml
@@ -1,0 +1,26 @@
+name: "[v5] Release"
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+  packages: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}-${{ github.event_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Release this GitHub Action
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 21
+          branches: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/v5-tests-and-release.yml
+++ b/.github/workflows/v5-tests-and-release.yml
@@ -1,5 +1,12 @@
 name: "[v5] Test and Release"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 permissions: read-all
 jobs:
   check-v4-compatibility:
@@ -381,10 +388,15 @@ jobs:
         shell: bash
 
   release:
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
+      pull-requests: write
       id-token: write
       packages: write
     concurrency:
@@ -397,6 +409,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Release this GitHub Action
-        uses: rlespinasse/release-that@v1
+        uses: cycjimmy/semantic-release-action@v4
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          semantic_version: 21
+          branches: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/v5-tests.yml
+++ b/.github/workflows/v5-tests.yml
@@ -1,6 +1,8 @@
 name: "[v5] Test"
 on:
   push:
+    branches:
+      - v5.x
   pull_request:
 permissions: read-all
 jobs:

--- a/.github/workflows/v5-tests.yml
+++ b/.github/workflows/v5-tests.yml
@@ -1,12 +1,7 @@
-name: "[v5] Test and Release"
+name: "[v5] Test"
 on:
   push:
-    branches:
-      - main
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
 permissions: read-all
 jobs:
   check-v4-compatibility:
@@ -386,32 +381,3 @@ jobs:
           [[ "${{ steps.using-nolimit-slug-max-length.outcome }}" == "success" ]]
           [[ "${{ steps.using-nolimit-slug-max-length.conclusion }}" == "success" ]]
         shell: bash
-
-  release:
-    if: |
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-      packages: write
-    concurrency:
-      group: release-${{ github.ref }}-${{ github.event_name }}
-    needs:
-      - display-without-checkout
-      - input-short-length-without-checkout
-      - input-slug-maxlength
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Release this GitHub Action
-        uses: cycjimmy/semantic-release-action@v4
-        with:
-          semantic_version: 21
-          branches: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,8 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["v5.x"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
- Update workflow triggers to support scheduled daily releases at UTC midnight
- Add workflow_dispatch for manual release triggering
- Add conditional logic to only run release on main branch pushes, schedules, or manual triggers
- Replace rlespinasse/release-that@v1 with cycjimmy/semantic-release-action@v4
- Switch from custom GH_TOKEN to standard GITHUB_TOKEN
- Create .releaserc.json with minimal semantic-release configuration
- Automatically analyzes conventional commits and generates releases
- Enables once-daily release cadence with unpublished commit detection